### PR TITLE
Add support for UBI images and additional architectures

### DIFF
--- a/cmd/cmrel/cmd/gcb_publish.go
+++ b/cmd/cmrel/cmd/gcb_publish.go
@@ -168,6 +168,15 @@ func runGCBPublish(rootOpts *rootOptions, o *gcbPublishOptions) error {
 		}
 	}
 
+	for name, tars := range rel.UBIImageBundles {
+		log.Printf("Loading UBI release images for component %q into local docker daemon...", name)
+		for _, t := range tars {
+			if err := docker.Load(t.Filepath()); err != nil {
+				return err
+			}
+		}
+	}
+
 	if !o.NoMock {
 		log.Printf("--nomock flag set to false, skipping actually publishing the release")
 		return nil
@@ -243,7 +252,29 @@ func pushRelease(o *gcbPublishOptions, rel *release.Unpacked) error {
 		builtManifestLists = append(builtManifestLists, manifestListName)
 	}
 
-	log.Printf("Pushing multi-arch manifest lists")
+	log.Printf("Pushing arch-specific UBI docker images")
+	for name, tars := range rel.UBIImageBundles {
+		log.Printf("Pushing UBI release images for component %q", name)
+		for _, t := range tars {
+			if err := docker.Push(t.ImageName()); err != nil {
+				return err
+			}
+			log.Printf("Pushed UBI release image %q", t.ImageName())
+			// Wait 2 seconds to avoid being rate limited by the registry.
+			time.Sleep(time.Second * 2)
+		}
+	}
+
+	log.Printf("Creating multi-arch manifest lists for UBI image components")
+	for name, tars := range rel.UBIImageBundles {
+		manifestListName := buildManifestListName(o.PublishedImageRepository, name, rel.ReleaseVersion)
+		if err := registry.CreateManifestList(manifestListName, tars); err != nil {
+			return err
+		}
+		builtManifestLists = append(builtManifestLists, manifestListName)
+	}
+
+	log.Printf("Pushing all multi-arch manifest lists")
 	for _, manifestListName := range builtManifestLists {
 		log.Printf("Pushing manifest list %q", manifestListName)
 		if err := docker.Command("", "manifest", "push", manifestListName); err != nil {

--- a/pkg/release/consts.go
+++ b/pkg/release/consts.go
@@ -74,7 +74,11 @@ var (
 	// for during the release.
 	// This is used to drive the `--platforms` flag passed to 'bazel build' as
 	// well as to determine which image artifacts should be uploaded.
-	ServerArchitectures = []string{"amd64", "arm", "arm64"}
+	ServerArchitectures = []string{"amd64", "arm", "arm64", "ppc64le", "s390x"}
+
+	// UBIArchitectures is defined separately as there is no 'arm' variant of
+	// the UBI8 base image.
+	UBIArchitectures = []string{"amd64", "arm64", "ppc64le", "s390x"}
 )
 
 // BucketPathForRelease will assemble an output directory path for the given


### PR DESCRIPTION
This adds support to the release tooling for the recently added UBI based docker images: https://github.com/jetstack/cert-manager/pull/2746

In order to have parity with Red Hat's own base image architectures, this also expands the number of architectures we release cert-manager for to include s390x and ppc64le.

/kind feature
/milestone v0.15