### PR TITLE
Validate built image name uses is correct/expected

### DIFF
--- a/pkg/release/validation/validate.go
+++ b/pkg/release/validation/validate.go
@@ -35,10 +35,12 @@ type Options struct {
 
 func ValidateUnpackedRelease(opts Options, rel *release.Unpacked) ([]string, error) {
 	var violations []string
-	for _, tars := range rel.ComponentImageBundles {
+	for componentName, tars := range rel.ComponentImageBundles {
 		for _, tar := range tars {
-			if !strings.HasPrefix(tar.ImageName(), opts.ImageRepository+"/") {
-				violations = append(violations, fmt.Sprintf("Image %q does not have prefix %q", tar.ImageName(), opts.ImageRepository+"/"))
+			expectedName := fmt.Sprintf("%s/cert-manager-%s-%s", opts.ImageRepository, componentName, tar.Architecture())
+			actualNameWithoutTag := strings.Split(tar.ImageName(), ":")[0]
+			if expectedName != actualNameWithoutTag {
+				violations = append(violations, fmt.Sprintf("Image %q does not match expected named %q", tar.ImageName(), actualNameWithoutTag))
 			}
 			if tar.ImageTag() != opts.ReleaseVersion {
 				violations = append(violations, fmt.Sprintf("Image %q does not have expected tag %q", tar.ImageName(), opts.ReleaseVersion))


### PR DESCRIPTION
See https://console.cloud.google.com/cloud-build/builds/aea169f4-5496-448d-b331-f8f4951fd402;step=2?project=cert-manager-release

The current release-0.15 branch is failing to release because the 'component name' is of the format `controller-ubi`, which is incorrect.

We need to improve the release tooling to better understand component names to work around this (or change how the artifacts are built in the cert-manager repo).

For now, this adds a check to the validator that will cause the release to fail earlier on if this happens.

/assign @meyskens 