### PR TITLE
Fix release version used for UBI manifest lists

### DIFF
--- a/cmd/cmrel/cmd/gcb_publish.go
+++ b/cmd/cmrel/cmd/gcb_publish.go
@@ -267,7 +267,7 @@ func pushRelease(o *gcbPublishOptions, rel *release.Unpacked) error {
 
 	log.Printf("Creating multi-arch manifest lists for UBI image components")
 	for name, tars := range rel.UBIImageBundles {
-		manifestListName := buildManifestListName(o.PublishedImageRepository, name, rel.ReleaseVersion)
+		manifestListName := buildManifestListName(o.PublishedImageRepository, name, rel.ReleaseVersion + "-ubi")
 		if err := registry.CreateManifestList(manifestListName, tars); err != nil {
 			return err
 		}


### PR DESCRIPTION
Avoids the following errors in the release publish step:
```
Step #2: 2020/04/08 14:55:18 Pushed UBI release image "quay.io/jetstack/cert-manager-controller-s390x:v0.15.0-alpha.0-ubi"
Step #2: 2020/04/08 14:55:20 Creating multi-arch manifest lists for UBI image components
Step #2: 2020/04/08 14:55:20 Creating manifest list "quay.io/jetstack/cert-manager-controller:v0.15.0-alpha.0"
Step #2: refusing to amend an existing manifest list with no --amend flag
Step #2: 2020/04/08 14:55:20 Failed to create manifest list with name "quay.io/jetstack/cert-manager-controller:v0.15.0-alpha.0" - ensure no existing manifest list exists with the same name, and ensure all member images are pushed to the remote registry.
Step #2: 2020/04/08 14:55:20 ERROR OCCURRED DURING PUBLISHING - INCOMPLETE RELEASE MAY BE PUBLISHED: exit status 1
```

/assign @meyskens 