### PR TITLE
Release CLI binaries as a .tar.gz

### DIFF
--- a/cmd/cmrel/cmd/gcb_publish.go
+++ b/cmd/cmrel/cmd/gcb_publish.go
@@ -225,9 +225,9 @@ func pushRelease(o *gcbPublishOptions, rel *release.Unpacked) error {
 		manifestsByName[filepath.Base(manifest.Path())] = f
 	}
 
-	// open ctl binary files ahead of time to ensure they are available on disk
+	// open ctl binary tar files ahead of time to ensure they are available on disk
 	ctlBinariesByName := map[string]*os.File{}
-	for _, files := range rel.CtlBinaries {
+	for _, files := range rel.CtlBinaryBundles {
 		for _, binary := range files {
 			f, err := os.Open(binary.Filepath())
 			if err != nil {

--- a/pkg/release/binaries/tar.go
+++ b/pkg/release/binaries/tar.go
@@ -16,32 +16,32 @@ limitations under the License.
 
 package binaries
 
-// Tar is used for accessing and interacting with a binary file stored on disk.
-type File struct {
-	// path is the path to the tar file containing the image on disk.
+// Tar is used for accessing and interacting with a tar wth a binary file stored on disk.
+type Tar struct {
+	// path is the path to the tar file containing the binary on disk.
 	path string
 
-	// os and arch of the image. This must be provided at instantiation time
+	// os and arch of the binary. This must be provided at instantiation time
 	// and cannot be determined by inspecting the tar file.
 	os, arch string
 }
 
-func NewFile(path, osStr, arch string) (*File, error) {
-	return &File{
+func NewFile(path, osStr, arch string) (*Tar, error) {
+	return &Tar{
 		path: path,
 		os:   osStr,
 		arch: arch,
 	}, nil
 }
 
-func (i *File) Filepath() string {
+func (i *Tar) Filepath() string {
 	return i.path
 }
 
-func (i *File) OS() string {
+func (i *Tar) OS() string {
 	return i.os
 }
 
-func (i *File) Architecture() string {
+func (i *Tar) Architecture() string {
 	return i.arch
 }


### PR DESCRIPTION
Makes changes to the new binary name and to release it as a .tar.gz

I still refer to it in the function names as `ctl` not to make the names too long, alternative names welcome!