### PR TITLE
Revert "Add darwin/arm64 to list of os/arch for client binaries"

### DIFF
--- a/pkg/release/consts.go
+++ b/pkg/release/consts.go
@@ -83,7 +83,7 @@ var (
 	// This is used to determine which artifacts should be uploaded.
 	ClientPlatforms = map[string][]string{
 		"linux":   []string{"amd64", "arm", "arm64", "ppc64le", "s390x"},
-		"darwin":  []string{"amd64", "arm64"},
+		"darwin":  []string{"amd64"},
 		"windows": []string{"amd64"},
 	}
 
@@ -91,7 +91,7 @@ var (
 	// This is used to drive the `--platforms` flag passed to 'bazel build'
 	ArchitecturesPerOS = map[string][]string{
 		"linux":   []string{"amd64", "arm", "arm64", "ppc64le", "s390x"},
-		"darwin":  []string{"amd64", "arm64"},
+		"darwin":  []string{"amd64"},
 		"windows": []string{"amd64"},
 	}
 )


### PR DESCRIPTION
Reverting as it seems to have not worked https://github.com/cert-manager/release/issues/25#issuecomment-840588355.

Apologies for the noise.

Reverts cert-manager/release#26

/kind cleanup