### PR TITLE
Docker image with cmrel and release-notes

### DIFF
--- a/.github/workflows/cmrel.yml
+++ b/.github/workflows/cmrel.yml
@@ -1,0 +1,43 @@
+name: cmrel-image
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+  pull_request:
+
+env:
+  IMAGE_NAME: cmrel
+
+jobs:
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: docker build . --tag $IMAGE_NAME
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:alpine as builder
+
+RUN go install github.com/cert-manager/release/cmd/cmrel@latest
+RUN go install k8s.io/release/cmd/release-notes@v0.7.0
+
+FROM alpine
+COPY --from=builder /go/bin/* /usr/local/bin/


### PR DESCRIPTION
Fixes #31.

@jakexks Is it OK if I publish the `cmrel` images to ghcr.io? 

Usage:

```sh
docker build . -t cmrel
docker run -it cmrel cmrel 
docker run -it cmrel release-notes
```