### PR TITLE
Sort versions when running "cmrel staged" and add cmrel staged --help

### DIFF
--- a/cmd/cmrel/cmd/staged.go
+++ b/cmd/cmrel/cmd/staged.go
@@ -21,12 +21,12 @@ import (
 	"fmt"
 	"log"
 	"sort"
-	"strings"
 	"text/tabwriter"
 
 	"cloud.google.com/go/storage"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
+	"golang.org/x/mod/semver"
 
 	"github.com/cert-manager/release/pkg/release"
 )
@@ -74,7 +74,7 @@ The output is sorted lexicographically using the version string:
 If you already know the release version (and since you have run 'cmrel stage',
 you probably do), you can select just these versions:
 
-	cmrel staged --release-version=v1.3.0
+	cmrel staged --release-version=v1.3.1
 
 which will only show the releases that you are interested in:
 
@@ -196,5 +196,5 @@ type ByVersion []release.Staged
 func (a ByVersion) Len() int      { return len(a) }
 func (a ByVersion) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a ByVersion) Less(i, j int) bool {
-	return strings.Compare(a[i].Metadata().ReleaseVersion, a[j].Metadata().ReleaseVersion) < 0
+	return semver.Compare(a[i].Metadata().ReleaseVersion, a[j].Metadata().ReleaseVersion) < 0
 }

--- a/cmd/cmrel/cmd/staged.go
+++ b/cmd/cmrel/cmd/staged.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"cloud.google.com/go/storage"
@@ -30,25 +32,74 @@ import (
 )
 
 const (
-	stagedCommand         = "staged"
-	stagedDescription     = "Staged release tarballs to a GCS release bucket"
-	stagedLongDescription = `The staged command will build and staged a cert-manager release to a
-Google Cloud Storage bucket. It will create a Google Cloud Build job
-which will run a full cross-build and publish the artifacts to the
-staging release bucket.
-`
+	stagedCommand     = "staged"
+	stagedDescription = "List existing staged releases in the GCS bucket, sorted by version."
 )
 
 var (
-	stagedExample = fmt.Sprintf(`
-To staged a release of the 'master' branch to the default staging bucket, run:
+	stagedExample = fmt.Sprint(`
+Imagine that you just ran 'cmrel stage', and you now want to run 'cmrel publish',
+which requires you to know the "release name" (--release-name).
 
-	%s %s --git-ref=master
+    v1.0.0-alpha.1-ae6a747fd4495a24db00ce4c1522c6eac72bc5a4
 
-To staged a release of the 'release-0.14' branch to the default staging bucket,
-overriding the release version as 'v0.14.0', run:
+The "staged" command will help you find this release name. To list the existing
+staged releases, run:
 
-	%s %s --git-ref=release-0.14 --release-version=v0.14.0`, rootCommand, stagedCommand, rootCommand, stagedCommand)
+    cmrel staged
+
+The output is sorted lexicographically using the version string:
+
+    NAME                                                      VERSION
+    v1.0.2-219b7934ac499c7818526597cf635a922bddd22e           v1.0.2
+    v1.0.3-cbd52ed6e9c296012bab87d3877d31e1f1295fa5           v1.0.3
+    v1.0.4-4d870e49b43960fad974487a262395e65da1373e           v1.0.4
+    v1.1.0-7fbdd6487646e812fe74c0c05503805b5d9d4751           v1.1.0
+    v1.1.0-alpha.0-09f043d2c96da68ed8d4f2c71a868fe0846d3669   v1.1.0-alpha.0
+    v1.1.0-alpha.1-fda1c091e3f37046c378bbf832e603284b6db531   v1.1.0-alpha.1
+    v1.1.1-3ac7418070e22c87fae4b22603a6b952f797ae96           v1.1.1
+    v1.2.0-969b678f330c68a6429b7a71b271761c59651a85           v1.2.0
+    v1.2.0-alpha.0-7cef4582ec8e33ff2f3b8dcf15b3f293f6ef82cc   v1.2.0-alpha.0
+    v1.2.0-alpha.1-33f18811909bdd08d39fd8aa3f016734d1393d18   v1.2.0-alpha.1
+    v1.2.0-alpha.2-35febb171706826f27d71af466c624c25733c135   v1.2.0-alpha.2
+    v1.3.0-9c42eeebfd3978531b517277a21e28e3cf90b876           v1.3.0
+    v1.3.0-alpha.0-77b045d159bd20ce0ec454cd79a5edce9187bdd9   v1.3.0-alpha.0
+    v1.3.0-alpha.1-c2c0fdd78131493707050ffa4a7454885d041b08   v1.3.0-alpha.1
+    v1.3.0-beta.0-9f612f0c2eee8390fb730b1aafa592b88d768d15    v1.3.0-beta.0
+    v1.3.1-614438aed00e1060870b273f2238794ef69b60ab           v1.3.1
+    v1.4.0-alpha.1-0ff2b8778c51e6cebe140a6b196e7a9a28cbee87   v1.4.0-alpha.1
+    v1.4.0-alpha.0-8d794c6bcf3bb02b9961bbd40f5b821f5636cceb   v1.4.0-wallrj.1
+    v1.4.0-wallrj.2-0ff2b8778c51e6cebe140a6b196e7a9a28cbee87  v1.4.0-wallrj.2
+
+If you already know the release version (and since you have run 'cmrel stage',
+you probably do), you can select just these versions:
+
+	cmrel staged --release-version=v1.3.0
+
+which will only show the releases that you are interested in:
+
+    NAME                                                      VERSION
+    v1.3.1-614438aed00e1060870b273f2238794ef69b60ab           v1.3.1
+
+The "release name" that you need to pass as --release-name to 'cmrel publish'
+is the string:
+
+    v1.3.1-614438aed00e1060870b273f2238794ef69b60ab
+
+Note that by default, the command will only show the "release" type, not the
+"devel" ones. To see the "devel" staged releases, you need to run:
+
+	cmrel staged --release-type=devel
+
+This time, no version will be shown, just the git commit hash:
+
+    NAME                                     VERSION
+    29406bfaa25c33661ff31b4d60a74f7b04ab6f2d
+    3c43140e9e7a6fc04e0e7ba0d50faeaa6aea97df
+    b95836421f7f3d2bbbebaa4fa3cca7128e3a97ad
+    dfafd10391b00d65315624dbbdc840d21735b240
+    ece63038d00e62711443a5abbc0e87b15a1367c1
+`)
 )
 
 type stagedOptions struct {
@@ -72,7 +123,7 @@ func (o *stagedOptions) AddFlags(fs *flag.FlagSet, markRequired func(string)) {
 	fs.StringVar(&o.Bucket, "bucket", release.DefaultBucketName, "The name of the GCS bucket containing the staged releases.")
 	fs.StringVar(&o.GitRef, "git-ref", "", "Optional specific git reference to list staged releases for - if specified, --release-version must also be specified.")
 	fs.StringVar(&o.ReleaseVersion, "release-version", "", "Optional release version override used to force the version strings used during the release to a specific value.")
-	fs.StringVar(&o.ReleaseType, "release-type", "release", "The type of release to list - usually one of 'release' or 'devel'")
+	fs.StringVar(&o.ReleaseType, "release-type", "release", "The type of release to list, usually one of 'release' or 'devel'")
 }
 
 func (o *stagedOptions) print() {
@@ -88,10 +139,9 @@ func stagedCmd(rootOpts *rootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          stagedCommand,
 		Short:        stagedDescription,
-		Long:         stagedLongDescription,
 		Example:      stagedExample,
 		SilenceUsage: true,
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			o.print()
 			log.Printf("---")
 		},
@@ -103,7 +153,7 @@ func stagedCmd(rootOpts *rootOptions) *cobra.Command {
 	return cmd
 }
 
-func runStaged(rootOpts *rootOptions, o *stagedOptions) error {
+func runStaged(_ *rootOptions, o *stagedOptions) error {
 	if o.ReleaseVersion == "" && o.GitRef != "" {
 		return fmt.Errorf("cannot specify --git-ref without --release-version")
 	}
@@ -120,6 +170,7 @@ func runStaged(rootOpts *rootOptions, o *stagedOptions) error {
 	}
 
 	lines := []string{"NAME\tVERSION\tDATE"}
+	sort.Sort(ByVersion(stagedReleases))
 	for _, rel := range stagedReleases {
 		vers := rel.Metadata().ReleaseVersion
 		lines = append(lines, fmt.Sprintf("%s\t%s\tUNKNOWN", rel.Name(), vers))
@@ -138,4 +189,12 @@ func logTable(lines ...string) {
 		fmt.Fprintln(w, l)
 	}
 	w.Flush()
+}
+
+type ByVersion []release.Staged
+
+func (a ByVersion) Len() int      { return len(a) }
+func (a ByVersion) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ByVersion) Less(i, j int) bool {
+	return strings.Compare(a[i].Metadata().ReleaseVersion, a[j].Metadata().ReleaseVersion) < 0
 }

--- a/cmd/cmrel/cmd/staged.go
+++ b/cmd/cmrel/cmd/staged.go
@@ -169,11 +169,11 @@ func runStaged(_ *rootOptions, o *stagedOptions) error {
 		return fmt.Errorf("failed listing staged releases: %w", err)
 	}
 
-	lines := []string{"NAME\tVERSION\tDATE"}
+	lines := []string{"NAME\tVERSION"}
 	sort.Sort(ByVersion(stagedReleases))
 	for _, rel := range stagedReleases {
 		vers := rel.Metadata().ReleaseVersion
-		lines = append(lines, fmt.Sprintf("%s\t%s\tUNKNOWN", rel.Name(), vers))
+		lines = append(lines, fmt.Sprintf("%s\t%s", rel.Name(), vers))
 	}
 
 	logTable(lines...)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/mod v0.4.1 // indirect
 	golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84
 	google.golang.org/api v0.43.0
 	k8s.io/apimachinery v0.20.5


### PR DESCRIPTION
Running `staged` was quite confusing since the versions would show in some random order. It now sorts versions lexicographically which means that the bottom lines are the latest tags.

Before:

```sh
% cmrel staged
NAME                                                           VERSION               DATE
v0.14.0-alpha.0-b057a72b467914a569329f45e0dc02bcfd9a8099       v0.14.0-alpha.0       UNKNOWN
v0.14.0-fullrelease.1-f6da9c76877551ef32503b17189bb178501f59a7 v0.14.0-fullrelease.1 UNKNOWN
v0.15.0-1d6ecc9cf8d841782acb5f3d3c28467c24c5fd18               v0.15.0               UNKNOWN
v1.1.0-alpha.1-fda1c091e3f37046c378bbf832e603284b6db531        v1.1.0-alpha.1        UNKNOWN
v1.2.0-alpha.1-33f18811909bdd08d39fd8aa3f016734d1393d18        v1.2.0-alpha.1        UNKNOWN
v1.2.0-alpha.2-35febb171706826f27d71af466c624c25733c135        v1.2.0-alpha.2        UNKNOWN
v1.3.0-beta.0-9f612f0c2eee8390fb730b1aafa592b88d768d15         v1.3.0-beta.0         UNKNOWN
v0.16.0-b14a7f2dfbc16b5a1228173f1a4de8985e66dbf3               v0.16.0               UNKNOWN
v1.1.1-3ac7418070e22c87fae4b22603a6b952f797ae96                v1.1.1                UNKNOWN
v0.14.0-josh.1-dfafd10391b00d65315624dbbdc840d21735b240        v0.14.0-josh.1        UNKNOWN
v1.1.0-7fbdd6487646e812fe74c0c05503805b5d9d4751                v1.1.0                UNKNOWN
v1.3.0-alpha.1-c2c0fdd78131493707050ffa4a7454885d041b08        v1.3.0-alpha.1        UNKNOWN
v1.4.0-alpha.1-0ff2b8778c51e6cebe140a6b196e7a9a28cbee87        v1.4.0-alpha.1        UNKNOWN
v0.14.0-newproject.1-f6da9c76877551ef32503b17189bb178501f59a7  v0.14.0-newproject.1  UNKNOWN
v1.0.0-28f102f3333e471a60d090fca6ca7f299e1285fb                v1.0.0                UNKNOWN
v1.0.4-4d870e49b43960fad974487a262395e65da1373e                v1.0.4                UNKNOWN
v1.3.0-9c42eeebfd3978531b517277a21e28e3cf90b876                v1.3.0                UNKNOWN
v0.14.0-alpha.1-e781549b645c69ef26d07c66d710096520557d5f       v0.14.0-alpha.1       UNKNOWN
v0.14.0-james.1-dfafd10391b00d65315624dbbdc840d21735b240       v0.14.0-james.1       UNKNOWN
v0.15.2-ce9d9c1c19acb491408af0e5a578a239969d7779               v0.15.2               UNKNOWN
v1.0.0-alpha.0-967bf850685362b95550607b2eee5cd7464ab4a7        v1.0.0-alpha.0        UNKNOWN
v1.0.3-cbd52ed6e9c296012bab87d3877d31e1f1295fa5                v1.0.3                UNKNOWN
v1.4.0-alpha.0-8d794c6bcf3bb02b9961bbd40f5b821f5636cceb        v1.4.0-richardw.1     UNKNOWN
v1.4.0-richardw.2-0ff2b8778c51e6cebe140a6b196e7a9a28cbee87     v1.4.0-richardw.2     UNKNOWN
v0.15-alpha.3-f25f887c6a9131d9f133a47cb40fea01ffafb3d0         v0.15-alpha.3         UNKNOWN
v0.15.0-alpha.0-fba7b09ac84021e064557c2022d7b51f9e31a0b0       v0.15.0-alpha.0       UNKNOWN
v1.0.0-beta.0-85a9044c0c15aac23a78d3523961ba2e23893c66         v1.0.0-beta.0         UNKNOWN
v1.1.0-alpha.0-09f043d2c96da68ed8d4f2c71a868fe0846d3669        v1.1.0-alpha.0        UNKNOWN
v1.3.0-alpha.0-77b045d159bd20ce0ec454cd79a5edce9187bdd9        v1.3.0-alpha.0        UNKNOWN
v0.15.0-beta.1-b893ee4e77f03e3a25782f7dba9572541cc96235        v0.15.0-beta.1        UNKNOWN
v0.14.1-c030d921b3b92326733e921fd53270f6be2b81be               v0.14.1               UNKNOWN
v0.15.0-alpha.1-49e1a7a51c71307718d29c4275bf3916906011c2       v0.15.0-alpha.1       UNKNOWN
v0.16.0-alpha.1-54605ff68ad0aaae8a31fcdf48e5d245cd29ee62       v0.16.0-alpha.1       UNKNOWN
v1.0.2-219b7934ac499c7818526597cf635a922bddd22e                v1.0.2                UNKNOWN
v0.15.0-maartje.5-223775cb2415fc710e8c12bceddacdb1c80f8184     v0.15.0-maartje.5     UNKNOWN
v1.0.0-alpha.1-ae6a747fd4495a24db00ce4c1522c6eac72bc5a4        v1.0.0-alpha.1        UNKNOWN
v1.0.1-c06d7a55dafb1a812321bf3c2ab982daa7b3e699                v1.0.1                UNKNOWN
v1.2.0-969b678f330c68a6429b7a71b271761c59651a85                v1.2.0                UNKNOWN
v0.15.0-maartje.0-d768862c3f8cf6d3dc560536051eef35ab659c91     v0.15.0-maartje.0     UNKNOWN
v0.14.0-alpha.0-b48988ffcf5eb9e5c7f6b93284a9867c811fd95b       v0.14.0-alpha.0       UNKNOWN
v0.14.2-8bc03dc303d0e4267e44dab0a68607f35786919e               v0.14.2               UNKNOWN
v0.15.0-alpha.2-f0231cc5d5a7f74fa0d77395546cef2cd0b80efd       v0.15.0-alpha.2       UNKNOWN
v1.3.1-614438aed00e1060870b273f2238794ef69b60ab                v1.3.1                UNKNOWN
v0.14.0-alpha.0-6da95758a4751b20cf85b29a3252e993449660eb       v0.14.0-alpha.0       UNKNOWN
v1.0.2-cafefa09d028ae56a12b1ee7d3635f8947f4f471                v1.0.2                UNKNOWN
v1.2.0-alpha.0-7cef4582ec8e33ff2f3b8dcf15b3f293f6ef82cc        v1.2.0-alpha.0        UNKNOWN
v1.4.0-beta.0-528305b5edd3e582a0996d20556a33d5b795564a         v1.4.0-beta.0         UNKNOWN
v0.14.0-newproject.1-8e511bfbbcd9230f1b30441c1e8ca16e40ab1446  v0.14.0-newproject.1  UNKNOWN
v0.14.3-7fb4ced3ca5ed6391c50ba07cae3d99f21424523               v0.14.3               UNKNOWN
v0.14.0-6da95758a4751b20cf85b29a3252e993449660eb               v0.14.0               UNKNOWN
v0.15.0-beta.0-67ffe495150a88623bb341a148fc821def285863        v0.15.0-beta.0        UNKNOWN
v0.15.1-4a4d9c626819fc6915196c8c0274e157fa6cec03               v0.15.1               UNKNOWN
v0.15.1-c9320bafda41ff726f0dfb22443fa813d5e34279               v0.15.1               UNKNOWN
v0.16.0-alpha.0-8867a35cb16421b56cfce55dac4576909ff39b7b       v0.16.0-alpha.0       UNKNOWN
v1.0.0-beta.1-57034dc1e47d0231d781cb8fe1ab58375fab5faf         v1.0.0-beta.1         UNKNOWN
v0.16.1-a7f8065abe6b74cbed35e79e4d646a38eb7ad6ae               v0.16.1               UNKNOWN
v0.15.0-beta.0-b915cc318a580738c444413e127829f5985675d3        v0.15.0-beta.0        UNKNOWN
v0.15.0-maartje.1-223775cb2415fc710e8c12bceddacdb1c80f8184     v0.15.0-maartje.1     UNKNOWN
```

After:

```sh
% cmrel staged
NAME                                                           VERSION               DATE
v0.14.0-6da95758a4751b20cf85b29a3252e993449660eb               v0.14.0               UNKNOWN
v0.14.0-alpha.0-b057a72b467914a569329f45e0dc02bcfd9a8099       v0.14.0-alpha.0       UNKNOWN
v0.14.0-alpha.0-b48988ffcf5eb9e5c7f6b93284a9867c811fd95b       v0.14.0-alpha.0       UNKNOWN
v0.14.0-alpha.0-6da95758a4751b20cf85b29a3252e993449660eb       v0.14.0-alpha.0       UNKNOWN
v0.14.0-alpha.1-e781549b645c69ef26d07c66d710096520557d5f       v0.14.0-alpha.1       UNKNOWN
v0.14.0-fullrelease.1-f6da9c76877551ef32503b17189bb178501f59a7 v0.14.0-fullrelease.1 UNKNOWN
v0.14.0-james.1-dfafd10391b00d65315624dbbdc840d21735b240       v0.14.0-james.1       UNKNOWN
v0.14.0-josh.1-dfafd10391b00d65315624dbbdc840d21735b240        v0.14.0-josh.1        UNKNOWN
v0.14.0-newproject.1-8e511bfbbcd9230f1b30441c1e8ca16e40ab1446  v0.14.0-newproject.1  UNKNOWN
v0.14.0-newproject.1-f6da9c76877551ef32503b17189bb178501f59a7  v0.14.0-newproject.1  UNKNOWN
v0.14.1-c030d921b3b92326733e921fd53270f6be2b81be               v0.14.1               UNKNOWN
v0.14.2-8bc03dc303d0e4267e44dab0a68607f35786919e               v0.14.2               UNKNOWN
v0.14.3-7fb4ced3ca5ed6391c50ba07cae3d99f21424523               v0.14.3               UNKNOWN
v0.15-alpha.3-f25f887c6a9131d9f133a47cb40fea01ffafb3d0         v0.15-alpha.3         UNKNOWN
v0.15.0-1d6ecc9cf8d841782acb5f3d3c28467c24c5fd18               v0.15.0               UNKNOWN
v0.15.0-alpha.0-fba7b09ac84021e064557c2022d7b51f9e31a0b0       v0.15.0-alpha.0       UNKNOWN
v0.15.0-alpha.1-49e1a7a51c71307718d29c4275bf3916906011c2       v0.15.0-alpha.1       UNKNOWN
v0.15.0-alpha.2-f0231cc5d5a7f74fa0d77395546cef2cd0b80efd       v0.15.0-alpha.2       UNKNOWN
v0.15.0-beta.0-67ffe495150a88623bb341a148fc821def285863        v0.15.0-beta.0        UNKNOWN
v0.15.0-beta.0-b915cc318a580738c444413e127829f5985675d3        v0.15.0-beta.0        UNKNOWN
v0.15.0-beta.1-b893ee4e77f03e3a25782f7dba9572541cc96235        v0.15.0-beta.1        UNKNOWN
v0.15.0-maartje.0-d768862c3f8cf6d3dc560536051eef35ab659c91     v0.15.0-maartje.0     UNKNOWN
v0.15.0-maartje.1-223775cb2415fc710e8c12bceddacdb1c80f8184     v0.15.0-maartje.1     UNKNOWN
v0.15.0-maartje.5-223775cb2415fc710e8c12bceddacdb1c80f8184     v0.15.0-maartje.5     UNKNOWN
v0.15.1-4a4d9c626819fc6915196c8c0274e157fa6cec03               v0.15.1               UNKNOWN
v0.15.1-c9320bafda41ff726f0dfb22443fa813d5e34279               v0.15.1               UNKNOWN
v0.15.2-ce9d9c1c19acb491408af0e5a578a239969d7779               v0.15.2               UNKNOWN
v0.16.0-b14a7f2dfbc16b5a1228173f1a4de8985e66dbf3               v0.16.0               UNKNOWN
v0.16.0-alpha.0-8867a35cb16421b56cfce55dac4576909ff39b7b       v0.16.0-alpha.0       UNKNOWN
v0.16.0-alpha.1-54605ff68ad0aaae8a31fcdf48e5d245cd29ee62       v0.16.0-alpha.1       UNKNOWN
v0.16.1-a7f8065abe6b74cbed35e79e4d646a38eb7ad6ae               v0.16.1               UNKNOWN
v1.0.0-28f102f3333e471a60d090fca6ca7f299e1285fb                v1.0.0                UNKNOWN
v1.0.0-alpha.0-967bf850685362b95550607b2eee5cd7464ab4a7        v1.0.0-alpha.0        UNKNOWN
v1.0.0-alpha.1-ae6a747fd4495a24db00ce4c1522c6eac72bc5a4        v1.0.0-alpha.1        UNKNOWN
v1.0.0-beta.0-85a9044c0c15aac23a78d3523961ba2e23893c66         v1.0.0-beta.0         UNKNOWN
v1.0.0-beta.1-57034dc1e47d0231d781cb8fe1ab58375fab5faf         v1.0.0-beta.1         UNKNOWN
v1.0.1-c06d7a55dafb1a812321bf3c2ab982daa7b3e699                v1.0.1                UNKNOWN
v1.0.2-cafefa09d028ae56a12b1ee7d3635f8947f4f471                v1.0.2                UNKNOWN
v1.0.2-219b7934ac499c7818526597cf635a922bddd22e                v1.0.2                UNKNOWN
v1.0.3-cbd52ed6e9c296012bab87d3877d31e1f1295fa5                v1.0.3                UNKNOWN
v1.0.4-4d870e49b43960fad974487a262395e65da1373e                v1.0.4                UNKNOWN
v1.1.0-7fbdd6487646e812fe74c0c05503805b5d9d4751                v1.1.0                UNKNOWN
v1.1.0-alpha.0-09f043d2c96da68ed8d4f2c71a868fe0846d3669        v1.1.0-alpha.0        UNKNOWN
v1.1.0-alpha.1-fda1c091e3f37046c378bbf832e603284b6db531        v1.1.0-alpha.1        UNKNOWN
v1.1.1-3ac7418070e22c87fae4b22603a6b952f797ae96                v1.1.1                UNKNOWN
v1.2.0-969b678f330c68a6429b7a71b271761c59651a85                v1.2.0                UNKNOWN
v1.2.0-alpha.0-7cef4582ec8e33ff2f3b8dcf15b3f293f6ef82cc        v1.2.0-alpha.0        UNKNOWN
v1.2.0-alpha.1-33f18811909bdd08d39fd8aa3f016734d1393d18        v1.2.0-alpha.1        UNKNOWN
v1.2.0-alpha.2-35febb171706826f27d71af466c624c25733c135        v1.2.0-alpha.2        UNKNOWN
v1.3.0-9c42eeebfd3978531b517277a21e28e3cf90b876                v1.3.0                UNKNOWN
v1.3.0-alpha.0-77b045d159bd20ce0ec454cd79a5edce9187bdd9        v1.3.0-alpha.0        UNKNOWN
v1.3.0-alpha.1-c2c0fdd78131493707050ffa4a7454885d041b08        v1.3.0-alpha.1        UNKNOWN
v1.3.0-beta.0-9f612f0c2eee8390fb730b1aafa592b88d768d15         v1.3.0-beta.0         UNKNOWN
v1.3.1-614438aed00e1060870b273f2238794ef69b60ab                v1.3.1                UNKNOWN
v1.4.0-alpha.1-0ff2b8778c51e6cebe140a6b196e7a9a28cbee87        v1.4.0-alpha.1        UNKNOWN
v1.4.0-beta.0-528305b5edd3e582a0996d20556a33d5b795564a         v1.4.0-beta.0         UNKNOWN
v1.4.0-alpha.0-8d794c6bcf3bb02b9961bbd40f5b821f5636cceb        v1.4.0-richardw.1     UNKNOWN
v1.4.0-richardw.2-0ff2b8778c51e6cebe140a6b196e7a9a28cbee87     v1.4.0-richardw.2     UNKNOWN
```

---

The `--help` had been copied from the `stage` command, so it was not really helpful. I tried to improve the help a little 😅

Before:

```sh
% cmrel staged --help                                        
cmrelThe staged command will build and staged a cert-manager release to a
Google Cloud Storage bucket. It will create a Google Cloud Build job
which will run a full cross-build and publish the artifacts to the
staging release bucket.

Usage:
  cmrel staged [flags]

Examples:

To staged a release of the 'master' branch to the default staging bucket, run: 

        cmrel staged --git-ref=master

To staged a release of the 'release-0.14' branch to the default staging bucket,
overriding the release version as 'v0.14.0', run:

        cmrel staged --git-ref=release-0.14 --release-version=v0.14.0

Flags:
      --bucket string            The name of the GCS bucket containing the staged releases. (default "cert-manager-release")
      --git-ref string           Optional specific git reference to list staged releases for - if specified, --release-version must also be specified.
  -h, --help                     help for staged
      --release-type string      The type of release to list - usually one of 'release' or 'devel' (default "release")
      --release-version string   Optional release version override used to force the version strings used during the release to a specific value.
```

After:

```sh
% cmrel staged --help   
cmrelList existing staged releases in the GCS bucket, sorted by version.

Usage:
  cmrel staged [flags]

Examples:

Imagine that you just ran 'cmrel stage', and you now want to run 'cmrel publish',
which requires you to know the "release name" (--release-name).

    v1.0.0-alpha.1-ae6a747fd4495a24db00ce4c1522c6eac72bc5a4

The "staged" command will help you find this release name. To list the existing
staged releases, run:

    cmrel staged

The output is sorted lexicographically using the version string:

    NAME                                                      VERSION
    v1.0.2-219b7934ac499c7818526597cf635a922bddd22e           v1.0.2
    v1.0.3-cbd52ed6e9c296012bab87d3877d31e1f1295fa5           v1.0.3
    v1.0.4-4d870e49b43960fad974487a262395e65da1373e           v1.0.4
    v1.1.0-7fbdd6487646e812fe74c0c05503805b5d9d4751           v1.1.0
    v1.1.0-alpha.0-09f043d2c96da68ed8d4f2c71a868fe0846d3669   v1.1.0-alpha.0
    v1.1.0-alpha.1-fda1c091e3f37046c378bbf832e603284b6db531   v1.1.0-alpha.1
    v1.1.1-3ac7418070e22c87fae4b22603a6b952f797ae96           v1.1.1
    v1.2.0-969b678f330c68a6429b7a71b271761c59651a85           v1.2.0
    v1.2.0-alpha.0-7cef4582ec8e33ff2f3b8dcf15b3f293f6ef82cc   v1.2.0-alpha.0
    v1.2.0-alpha.1-33f18811909bdd08d39fd8aa3f016734d1393d18   v1.2.0-alpha.1
    v1.2.0-alpha.2-35febb171706826f27d71af466c624c25733c135   v1.2.0-alpha.2
    v1.3.0-9c42eeebfd3978531b517277a21e28e3cf90b876           v1.3.0
    v1.3.0-alpha.0-77b045d159bd20ce0ec454cd79a5edce9187bdd9   v1.3.0-alpha.0
    v1.3.0-alpha.1-c2c0fdd78131493707050ffa4a7454885d041b08   v1.3.0-alpha.1
    v1.3.0-beta.0-9f612f0c2eee8390fb730b1aafa592b88d768d15    v1.3.0-beta.0
    v1.3.1-614438aed00e1060870b273f2238794ef69b60ab           v1.3.1
    v1.4.0-alpha.1-0ff2b8778c51e6cebe140a6b196e7a9a28cbee87   v1.4.0-alpha.1
    v1.4.0-alpha.0-8d794c6bcf3bb02b9961bbd40f5b821f5636cceb   v1.4.0-wallrj.1
    v1.4.0-wallrj.2-0ff2b8778c51e6cebe140a6b196e7a9a28cbee87  v1.4.0-wallrj.2

If you already know the release version (and since you have run 'cmrel stage',
you probably do), you can select just these versions:

        cmrel staged --release-version=v1.3.0

which will only show the releases that you are interested in:

    NAME                                                      VERSION
    v1.3.1-614438aed00e1060870b273f2238794ef69b60ab           v1.3.1

The "release name" that you need to pass as --release-name to 'cmrel publish'
is the string:

    v1.3.1-614438aed00e1060870b273f2238794ef69b60ab

Note that by default, the command will only show the "release" type, not the
"devel" ones. To see the "devel" staged releases, you need to run:

        cmrel staged --release-type=devel

This time, no version will be shown, just the git commit hash:

    NAME                                     VERSION
    29406bfaa25c33661ff31b4d60a74f7b04ab6f2d
    3c43140e9e7a6fc04e0e7ba0d50faeaa6aea97df
    b95836421f7f3d2bbbebaa4fa3cca7128e3a97ad
    dfafd10391b00d65315624dbbdc840d21735b240
    ece63038d00e62711443a5abbc0e87b15a1367c1


Flags:
      --bucket string            The name of the GCS bucket containing the staged releases. (default "cert-manager-release")
      --git-ref string           Optional specific git reference to list staged releases for - if specified, --release-version must also be specified.
  -h, --help                     help for staged
      --release-type string      The type of release to list, usually one of 'release' or 'devel' (default "release")
      --release-version string   Optional release version override used to force the version strings used during the release to a specific value.
```