### PR TITLE
cmrel staged is now sorted by version and has some --help

### DIFF
--- a/cmd/cmrel/cmd/staged.go
+++ b/cmd/cmrel/cmd/staged.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"cloud.google.com/go/storage"
@@ -30,25 +32,74 @@ import (
 )
 
 const (
-	stagedCommand         = "staged"
-	stagedDescription     = "Staged release tarballs to a GCS release bucket"
-	stagedLongDescription = `The staged command will build and staged a cert-manager release to a
-Google Cloud Storage bucket. It will create a Google Cloud Build job
-which will run a full cross-build and publish the artifacts to the
-staging release bucket.
-`
+	stagedCommand     = "staged"
+	stagedDescription = "List existing staged releases in the GCS bucket, sorted by version."
 )
 
 var (
-	stagedExample = fmt.Sprintf(`
-To staged a release of the 'master' branch to the default staging bucket, run: 
+	stagedExample = fmt.Sprint(`
+Imagine that you just ran 'cmrel stage', and you now want to run 'cmrel publish',
+which requires you to know the "release name" (--release-name).
 
-	%s %s --git-ref=master
+    v1.0.0-alpha.1-ae6a747fd4495a24db00ce4c1522c6eac72bc5a4
 
-To staged a release of the 'release-0.14' branch to the default staging bucket,
-overriding the release version as 'v0.14.0', run:
+The "staged" command will help you find this release name. To list the existing
+staged releases, run:
 
-	%s %s --git-ref=release-0.14 --release-version=v0.14.0`, rootCommand, stagedCommand, rootCommand, stagedCommand)
+    cmrel staged
+
+The output is sorted lexicographically using the version string:
+
+    NAME                                                      VERSION
+    v1.0.2-219b7934ac499c7818526597cf635a922bddd22e           v1.0.2
+    v1.0.3-cbd52ed6e9c296012bab87d3877d31e1f1295fa5           v1.0.3
+    v1.0.4-4d870e49b43960fad974487a262395e65da1373e           v1.0.4
+    v1.1.0-7fbdd6487646e812fe74c0c05503805b5d9d4751           v1.1.0
+    v1.1.0-alpha.0-09f043d2c96da68ed8d4f2c71a868fe0846d3669   v1.1.0-alpha.0
+    v1.1.0-alpha.1-fda1c091e3f37046c378bbf832e603284b6db531   v1.1.0-alpha.1
+    v1.1.1-3ac7418070e22c87fae4b22603a6b952f797ae96           v1.1.1
+    v1.2.0-969b678f330c68a6429b7a71b271761c59651a85           v1.2.0
+    v1.2.0-alpha.0-7cef4582ec8e33ff2f3b8dcf15b3f293f6ef82cc   v1.2.0-alpha.0
+    v1.2.0-alpha.1-33f18811909bdd08d39fd8aa3f016734d1393d18   v1.2.0-alpha.1
+    v1.2.0-alpha.2-35febb171706826f27d71af466c624c25733c135   v1.2.0-alpha.2
+    v1.3.0-9c42eeebfd3978531b517277a21e28e3cf90b876           v1.3.0
+    v1.3.0-alpha.0-77b045d159bd20ce0ec454cd79a5edce9187bdd9   v1.3.0-alpha.0
+    v1.3.0-alpha.1-c2c0fdd78131493707050ffa4a7454885d041b08   v1.3.0-alpha.1
+    v1.3.0-beta.0-9f612f0c2eee8390fb730b1aafa592b88d768d15    v1.3.0-beta.0
+    v1.3.1-614438aed00e1060870b273f2238794ef69b60ab           v1.3.1
+    v1.4.0-alpha.1-0ff2b8778c51e6cebe140a6b196e7a9a28cbee87   v1.4.0-alpha.1
+    v1.4.0-alpha.0-8d794c6bcf3bb02b9961bbd40f5b821f5636cceb   v1.4.0-wallrj.1
+    v1.4.0-wallrj.2-0ff2b8778c51e6cebe140a6b196e7a9a28cbee87  v1.4.0-wallrj.2
+
+If you already know the release version (and since you have run 'cmrel stage',
+you probably do), you can select just these versions:
+
+	cmrel staged --release-version=v1.3.0
+
+which will only show the releases that you are interested in:
+
+    NAME                                                      VERSION
+    v1.3.1-614438aed00e1060870b273f2238794ef69b60ab           v1.3.1
+
+The "release name" that you need to pass as --release-name to 'cmrel publish'
+is the string:
+
+    v1.3.1-614438aed00e1060870b273f2238794ef69b60ab
+
+Note that by default, the command will only show the "release" type, not the
+"devel" ones. To see the "devel" staged releases, you need to run:
+
+	cmrel staged --release-type=devel
+
+This time, no version will be shown, just the git commit hash:
+
+    NAME                                     VERSION
+    29406bfaa25c33661ff31b4d60a74f7b04ab6f2d
+    3c43140e9e7a6fc04e0e7ba0d50faeaa6aea97df
+    b95836421f7f3d2bbbebaa4fa3cca7128e3a97ad
+    dfafd10391b00d65315624dbbdc840d21735b240
+    ece63038d00e62711443a5abbc0e87b15a1367c1
+`)
 )
 
 type stagedOptions struct {
@@ -72,7 +123,7 @@ func (o *stagedOptions) AddFlags(fs *flag.FlagSet, markRequired func(string)) {
 	fs.StringVar(&o.Bucket, "bucket", release.DefaultBucketName, "The name of the GCS bucket containing the staged releases.")
 	fs.StringVar(&o.GitRef, "git-ref", "", "Optional specific git reference to list staged releases for - if specified, --release-version must also be specified.")
 	fs.StringVar(&o.ReleaseVersion, "release-version", "", "Optional release version override used to force the version strings used during the release to a specific value.")
-	fs.StringVar(&o.ReleaseType, "release-type", "release", "The type of release to list - usually one of 'release' or 'devel'")
+	fs.StringVar(&o.ReleaseType, "release-type", "release", "The type of release to list, usually one of 'release' or 'devel'")
 }
 
 func (o *stagedOptions) print() {
@@ -88,10 +139,9 @@ func stagedCmd(rootOpts *rootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          stagedCommand,
 		Short:        stagedDescription,
-		Long:         stagedLongDescription,
 		Example:      stagedExample,
 		SilenceUsage: true,
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			o.print()
 			log.Printf("---")
 		},
@@ -103,7 +153,7 @@ func stagedCmd(rootOpts *rootOptions) *cobra.Command {
 	return cmd
 }
 
-func runStaged(rootOpts *rootOptions, o *stagedOptions) error {
+func runStaged(_ *rootOptions, o *stagedOptions) error {
 	if o.ReleaseVersion == "" && o.GitRef != "" {
 		return fmt.Errorf("cannot specify --git-ref without --release-version")
 	}
@@ -120,6 +170,7 @@ func runStaged(rootOpts *rootOptions, o *stagedOptions) error {
 	}
 
 	lines := []string{"NAME\tVERSION\tDATE"}
+	sort.Sort(ByVersion(stagedReleases))
 	for _, rel := range stagedReleases {
 		vers := rel.Metadata().ReleaseVersion
 		lines = append(lines, fmt.Sprintf("%s\t%s\tUNKNOWN", rel.Name(), vers))
@@ -138,4 +189,12 @@ func logTable(lines ...string) {
 		fmt.Fprintln(w, l)
 	}
 	w.Flush()
+}
+
+type ByVersion []release.Staged
+
+func (a ByVersion) Len() int      { return len(a) }
+func (a ByVersion) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ByVersion) Less(i, j int) bool {
+	return strings.Compare(a[i].Metadata().ReleaseVersion, a[j].Metadata().ReleaseVersion) < 0
 }


### PR DESCRIPTION
This PR creates a new command `cmrel update-release-branch`, and the goal is to automate this part of our [release-process](https://cert-manager.io/docs/contributing/release-process/):

> 3. Create or update the release branch:
> 
>     - **(initial alpha only)** Create the release branch:
> 
>        ```bash
>        # Must be run from the cert-manager repo folder.
>        git fetch --all
>        git checkout -b release-1.0 origin/master
>        ```
> 
>     - **(subsequent alpha, beta and final releases only)**; You need to
>       update the release branch with the latest commits from the master
>       branch, as follows:
> 
>        ```bash
>        # Must be run from the cert-manager repo folder.
>        git fetch --all
>        git branch --force release-1.0 origin/release-1.0
>        git checkout release-1.0
>        git merge --ff-only origin/master
>        ```
> 
>        Patch releases do not require this `git merge --ff-only` step, since
>        the merge is done by opening a PR using the `/cherry-pick
>        release-1.0` command.
> 
> 4. Push the new or updated release branch:
> 
>     1. Check that the `origin` remote is correct. To do that, run the following
>         command and make sure it returns
>         the upstream `https://github.com/jetstack/cert-manager.git`:
> 
>         ```sh
>         # Must be run from the cert-manager repo folder.
>         git remote -v | grep origin
>         ```
> 
>     2. Push the release branch:
> 
>         ```bash
>         # Must be run from the cert-manager repo folder.
>         git push --set-upstream origin release-1.0
>         ```
> 
>         **(initial alpha only)**: `git push` will only work if you have the
>         `write` or `admin` GitHub permission on the cert-manager repo to create
>         or push to the branch, see [prerequisites](#prerequisites).
