### PR TITLE
Kubectl plugin for darwin arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,12 @@ to set the following flags when calling `cmrel publish`:
     --published-helm-chart-bucket='mycompany-helm-charts' # name of the GCS bucket where the built Helm chart should be stored
     --published-github-org='mycompany' # name of the GitHub org containing the repo that will be tagged at the end
 ```
+
+### Development
+
+#### Creating development builds
+
+By default the artifacts created during a release process are pushed to `cert-manager-release` bucket at `/stage/gcb/release` path.
+It is also possible to create a 'development' build by skipping the `--release-version` flag on `cmrel stage` command. This will result in the build artifacts being pushed to `cert-manager-release` bucket at `/stage/gcb/devel` path.
+
+If you have made some local changes to this tool and want to create a 'devel' build to test them, be mindful that the Google Cloud Build triggered by running `cmrel stage` clones this repository from GitHub and runs its own `cmrel` commands. You can modify the [Cloud Build config](https://github.com/cert-manager/release/blob/master/gcb/stage/cloudbuild.yaml) to configure a different GitHub repository/branch.

--- a/cmd/cmrel/cmd/stage.go
+++ b/cmd/cmrel/cmd/stage.go
@@ -70,7 +70,7 @@ type stageOptions struct {
 	// The path to the cloudbuild.yaml file used to perform the cert-manager crossbuild
 	CloudBuildFile string
 
-	// GCP project to run the GCB job in
+	// Project is the name of the GCP project to run the GCB job in
 	Project string
 
 	// ReleaseVersion, if set, overrides the version git version tag used

--- a/cmd/cmrel/cmd/stage.go
+++ b/cmd/cmrel/cmd/stage.go
@@ -41,14 +41,14 @@ staging release bucket.
 
 var (
 	stageExample = fmt.Sprintf(`
-To stage a release of the 'master' branch to the default staging bucket, run: 
+To stage a release of the 'master' branch to the default staging bucket at 'devel' path, run:
 
-	%s %s --git-ref=master
+	%s %s --branch=master
 
-To stage a release of the 'release-0.14' branch to the default staging bucket,
+To stage a release of the 'release-0.14' branch to the default staging bucket at 'release' path,
 overriding the release version as 'v0.14.0', run:
 
-	%s %s --git-ref=release-0.14 --release-version=v0.14.0`, rootCommand, stageCommand, rootCommand, stageCommand)
+	%s %s --branch=release-0.14 --release-version=v0.14.0`, rootCommand, stageCommand, rootCommand, stageCommand)
 )
 
 type stageOptions struct {
@@ -61,7 +61,7 @@ type stageOptions struct {
 	// Name of the GitHub repo to fetch cert-manager sources from
 	Repo string
 
-	// Name of the GitHub repo to build cert-manager sources from
+	// Name of the branch in the GitHub repo to build cert-manager sources from
 	Branch string
 
 	// Optional commit ref of cert-manager that should be staged
@@ -70,7 +70,7 @@ type stageOptions struct {
 	// The path to the cloudbuild.yaml file used to perform the cert-manager crossbuild
 	CloudBuildFile string
 
-	// Project to run the GCB job in
+	// GCP project to run the GCB job in
 	Project string
 
 	// ReleaseVersion, if set, overrides the version git version tag used
@@ -95,7 +95,7 @@ func (o *stageOptions) AddFlags(fs *flag.FlagSet, markRequired func(string)) {
 	fs.StringVar(&o.CloudBuildFile, "cloudbuild", "./gcb/stage/cloudbuild.yaml", "The path to the cloudbuild.yaml file used to perform the cert-manager crossbuild. "+
 		"The default value assumes that this tool is run from the root of the release repository.")
 	fs.StringVar(&o.Project, "project", release.DefaultReleaseProject, "The GCP project to run the GCB build jobs in.")
-	fs.StringVar(&o.ReleaseVersion, "release-version", "", "Optional release version override used to force the version strings used during the release to a specific value.")
+	fs.StringVar(&o.ReleaseVersion, "release-version", "", "Optional release version override used to force the version strings used during the release to a specific value. If not set, build is treated as development build and artifacts staged to 'devel' path.")
 	fs.StringVar(&o.PublishedImageRepository, "published-image-repo", release.DefaultImageRepository, "The docker image repository set when building the release.")
 	markRequired("branch")
 }

--- a/pkg/release/consts.go
+++ b/pkg/release/consts.go
@@ -91,7 +91,7 @@ var (
 	// This is used to determine which artifacts should be uploaded.
 	ClientPlatforms = map[string][]string{
 		"linux":   []string{"amd64", "arm", "arm64", "ppc64le", "s390x"},
-		"darwin":  []string{"amd64"},
+		"darwin":  []string{"amd64", "arm64"},
 		"windows": []string{"amd64"},
 	}
 
@@ -99,7 +99,7 @@ var (
 	// This is used to drive the `--platforms` flag passed to 'bazel build'
 	ArchitecturesPerOS = map[string][]string{
 		"linux":   []string{"amd64", "arm", "arm64", "ppc64le", "s390x"},
-		"darwin":  []string{"amd64"},
+		"darwin":  []string{"amd64", "arm64"},
 		"windows": []string{"amd64"},
 	}
 )


### PR DESCRIPTION
This PR updates the release tool to also build the cert-manager kubectl plugin for darwin/arm64.

Since, we already have darwin/arm64 in the list of supported os/arch combinations for the kubectl plugin in cert-manager codebase [here](https://github.com/jetstack/cert-manager/blob/master/build/platforms.bzl#L40) this was just a matter of ensuring that we build the release artifacts with `--platforms=@io_bazel_rules_go//go/toolchain:darwin_arm64` flag from `cmrel`.

I have also updated the README and `cmrel stage --help` output a little.

I've created a 'development' build with the updated `cmrel` tool here https://console.cloud.google.com/storage/browser/cert-manager-release/stage/gcb/devel/5875c828c68b9e22ec157508743e360017916190?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&authuser=1&project=cert-manager-release&prefix=&forceOnObjectsSortingFiltering=false - if anyone M1 Mac felt like trying this out 😅 

Fixes #25 , https://github.com/jetstack/cert-manager/issues/4052