### PR TITLE
Bump docker version used in codebuild

### DIFF
--- a/gcb/publish/cloudbuild.yaml
+++ b/gcb/publish/cloudbuild.yaml
@@ -31,7 +31,7 @@ steps:
     CGO_ENABLED=0 go build -o /workspace/go/bin/cmrel ./cmd/cmrel
 
 ## Write DOCKER_CONFIG file to $HOME/.docker/config.json
-- name: gcr.io/cloud-builders/docker:18.09.6
+- name: gcr.io/cloud-builders/docker:19.03.8
   entrypoint: bash
   secretEnv:
   - DOCKER_CONFIG
@@ -42,7 +42,7 @@ steps:
     echo "$${DOCKER_CONFIG}" > $$HOME/.docker/config.json
 
 ## Build and push the release artifacts
-- name: gcr.io/cloud-builders/docker:18.09.6
+- name: gcr.io/cloud-builders/docker:19.03.8
   dir: "go/src/github.com/jetstack/cert-manager"
   entrypoint: /workspace/go/bin/cmrel
   secretEnv:


### PR DESCRIPTION
Separated from #38  because I'm not 100% sure that this will be without any side effects.

There are even newer versions of docker available, but 19.03 was the latest updated in `gcr.io/cloud-builders/docker`. 