### PR TITLE
Minor cleanup of gcb stage command

### DIFF
--- a/cmd/cmrel/cmd/gcb_stage.go
+++ b/cmd/cmrel/cmd/gcb_stage.go
@@ -32,7 +32,6 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cert-manager/release/pkg/release"
 	"github.com/cert-manager/release/pkg/sign"
@@ -161,9 +160,9 @@ func runGCBStage(rootOpts *rootOptions, o *gcbStageOptions) error {
 	// of all the artifacts that were built during a `bazel run` invocation.
 	// This will mean we don't have to update this release tool whenever we add an additional
 	// release artifact.
+	osTargets := release.AllOSes()
 
-	allOSes := sets.NewString(append(append(platformMapKeys(release.ClientPlatforms), platformMapKeys(release.ServerPlatforms)...))...)
-	for _, osVariant := range allOSes.List() {
+	for _, osVariant := range osTargets {
 		for _, arch := range release.ArchitecturesPerOS[osVariant] {
 			log.Printf("Building %q target for %q OS for %q architecture", release.TarsBazelTarget, osVariant, arch)
 			if err := runBazel(o.RepoPath, bazelBuildEnv(o), "build", "--stamp", platformFlagForOSArch(osVariant, arch), release.TarsBazelTarget); err != nil {
@@ -384,13 +383,4 @@ func sha256SumFile(filename string) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(hasher.Sum(nil)), nil
-}
-
-func platformMapKeys(in map[string][]string) []string {
-	keys := make([]string, 0, len(in))
-	for k := range in {
-		keys = append(keys, k)
-	}
-
-	return keys
 }

--- a/pkg/release/consts.go
+++ b/pkg/release/consts.go
@@ -77,33 +77,6 @@ const (
 	BuildTypeDevel = "devel"
 )
 
-var (
-	// ServerPlatforms is the list of OSes and architectures to build docker images
-	// for during the release.
-	// This is used to drive the `--platforms` flag passed to 'bazel build' as
-	// well as to determine which image artifacts should be uploaded.
-	ServerPlatforms = map[string][]string{
-		"linux": []string{"amd64", "arm", "arm64", "ppc64le", "s390x"},
-	}
-
-	// ClientPlatforms is the list of OSes and architectures to build client CLI tools
-	// for during the release.
-	// This is used to determine which artifacts should be uploaded.
-	ClientPlatforms = map[string][]string{
-		"linux":   []string{"amd64", "arm", "arm64", "ppc64le", "s390x"},
-		"darwin":  []string{"amd64", "arm64"},
-		"windows": []string{"amd64"},
-	}
-
-	// ArchitecturesPerOS is the list of OSes and architectures that we can build
-	// This is used to drive the `--platforms` flag passed to 'bazel build'
-	ArchitecturesPerOS = map[string][]string{
-		"linux":   []string{"amd64", "arm", "arm64", "ppc64le", "s390x"},
-		"darwin":  []string{"amd64", "arm64"},
-		"windows": []string{"amd64"},
-	}
-)
-
 // BucketPathForRelease will assemble an output directory path for the given
 // release parameters.
 func BucketPathForRelease(bucketPrefix, buildType, releaseVersion, gitRef string) string {

--- a/pkg/release/platforms.go
+++ b/pkg/release/platforms.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+var (
+	// ServerPlatforms is the list of OSes and architectures to build docker images
+	// for during the release.
+	// This is used to drive the `--platforms` flag passed to 'bazel build' as
+	// well as to determine which image artifacts should be uploaded.
+	ServerPlatforms = map[string][]string{
+		"linux": []string{"amd64", "arm", "arm64", "ppc64le", "s390x"},
+	}
+
+	// ClientPlatforms is the list of OSes and architectures to build client CLI tools
+	// for during the release.
+	// This is used to determine which artifacts should be uploaded.
+	ClientPlatforms = map[string][]string{
+		"linux":   []string{"amd64", "arm", "arm64", "ppc64le", "s390x"},
+		"darwin":  []string{"amd64", "arm64"},
+		"windows": []string{"amd64"},
+	}
+
+	// ArchitecturesPerOS is the list of OSes and architectures that we can build
+	// This is used to drive the `--platforms` flag passed to 'bazel build'
+	ArchitecturesPerOS = map[string][]string{
+		"linux":   []string{"amd64", "arm", "arm64", "ppc64le", "s390x"},
+		"darwin":  []string{"amd64", "arm64"},
+		"windows": []string{"amd64"},
+	}
+)
+
+// AllOSes returns a slice of all known operating systems which cert-manager targets
+// including both server and client targets.
+func AllOSes() []string {
+	// initialise set with server platforms
+	platforms := sets.NewString(mapKeys(ServerPlatforms)...)
+
+	// add client platforms
+	platforms = platforms.Insert(mapKeys(ClientPlatforms)...)
+
+	return platforms.List()
+}
+
+func mapKeys(in map[string][]string) []string {
+	keys := make([]string, 0, len(in))
+	for k := range in {
+		keys = append(keys, k)
+	}
+
+	return keys
+}


### PR DESCRIPTION
This is mostly to clean up [this line](https://github.com/cert-manager/release/blob/4d52f6f9027b2330897cc2014e1af8628bc63d22/cmd/cmrel/cmd/gcb_stage.go#L165) which I found very hard to parse (and which has an extra append left over from previous changes).

This will also make it easier to add flags to specify a specific OS or arch to build later, by manually specifying a value for osTargets