### PR TITLE
Allow specifying manual arch/os combinations when staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ clean:
 .PHONY: test
 test:
 	@# TODO: this should be go test ./... but one of the tests was broken a while back and needs fixing first
+	go test ./pkg/release
 	go test ./pkg/release/helm
 	go test ./pkg/release/manifests
 	@# go test ./pkg/release/validation  # this one is broken

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -36,6 +36,8 @@ steps:
   - --bucket=${_RELEASE_BUCKET}
   - --signing-kms-key=${_KMS_KEY}
   - --skip-signing=${_SKIP_SIGNING}
+  - --target-os=${_TARGET_OSES}
+  - --target-arches=${_TARGET_ARCHES}
 
 tags:
 - "cert-manager-release-stage"
@@ -59,6 +61,9 @@ substitutions:
   # so we have to manually find an image with the desired version.
   _BAZEL_VERSION: 4.2.1
   _BAZEL_IMAGE_SHA: "sha256:9950b67658ab659f6efbe39f64e202f6f5bb15f7934b203f6132018410758d0c"
+  ## Options controlling which OSes and arches to build for where * means "all known"
+  _TARGET_OSES: "*"
+  _TARGET_ARCHES: "*"
   ## Options controlling the version of the release tooling used in the build.
   _RELEASE_REPO_URL: https://github.com/cert-manager/release.git
   _RELEASE_REPO_REF: "master"

--- a/pkg/release/platforms.go
+++ b/pkg/release/platforms.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package release
 
-import "k8s.io/apimachinery/pkg/util/sets"
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
 
 var (
 	// ServerPlatforms is the list of OSes and architectures to build docker images
@@ -47,15 +52,35 @@ var (
 
 // AllOSes returns a slice of all known operating systems which cert-manager targets
 // including both server and client targets.
-func AllOSes() []string {
+func AllOSes() sets.String {
 	// initialise set with server platforms
 	platforms := sets.NewString(mapKeys(ServerPlatforms)...)
 
 	// add client platforms
 	platforms = platforms.Insert(mapKeys(ClientPlatforms)...)
 
-	return platforms.List()
+	return platforms
 }
+
+// AllArchesForOSes returns all architectures targetted by any of the given OSes. Panics
+// if any of the OSes are unknown
+func AllArchesForOSes(osList sets.String) sets.String {
+	knownArches := sets.String{}
+
+	for _, os := range osList.List() {
+		arches, ok := ArchitecturesPerOS[os]
+		if !ok {
+			panic("unknown OS when trying to get architectures: " + os)
+		}
+
+		knownArches = knownArches.Insert(arches...)
+	}
+
+	return knownArches
+}
+
+// AllOSes returns a slice of all known architectures which cert-manager targets
+// including both server and client targets.
 
 func mapKeys(in map[string][]string) []string {
 	keys := make([]string, 0, len(in))
@@ -64,4 +89,86 @@ func mapKeys(in map[string][]string) []string {
 	}
 
 	return keys
+}
+
+// OSListFromString parses and validates a comma-separated list of OSes, returning an error if any are invalid or a slice
+// of valid OSes if all are OK.
+func OSListFromString(targetOSes string) (sets.String, error) {
+	allOSes := AllOSes()
+
+	splitList := strings.Split(strings.TrimSpace(targetOSes), ",")
+
+	if len(splitList) == 1 && splitList[0] == "*" {
+		return allOSes, nil
+	}
+
+	osListOut := sets.String{}
+
+	for _, rawOS := range splitList {
+		os := strings.ToLower(strings.TrimSpace(rawOS))
+
+		if len(os) == 0 {
+			continue
+		}
+
+		if !allOSes.Has(os) {
+			return nil, fmt.Errorf("unknown os %q", rawOS)
+		}
+
+		osListOut = osListOut.Insert(os)
+	}
+
+	if len(osListOut) == 0 {
+		return nil, fmt.Errorf("invalid OS list; no OSes specified")
+	}
+
+	return osListOut, nil
+}
+
+// ArchListFromString parses and validates a comma-separated list of arches, returning a slice of valid arches if all are OK.
+// Returns an error on an unknown architecture or an architecture which isn't a valid target for the given
+// OSes for this invocation (e.g. will error if osList == []string{"windows"} and targetArches == "s390x")
+// Panics if given an unknown OS
+func ArchListFromString(targetArches string, osList sets.String) (sets.String, error) {
+	allArches := AllArchesForOSes(osList)
+
+	splitList := strings.Split(targetArches, ",")
+
+	if len(splitList) == 1 && splitList[0] == "*" {
+		return allArches, nil
+	}
+
+	archListOut := sets.String{}
+
+	for _, rawArch := range splitList {
+		arch := strings.ToLower(strings.TrimSpace(rawArch))
+
+		if len(arch) == 0 {
+			continue
+		}
+
+		if !allArches.Has(arch) {
+			return nil, fmt.Errorf("unknown arch %q; if it's a valid arch, it might not be supported on any of the given OSes", rawArch)
+		}
+
+		archListOut = archListOut.Insert(arch)
+	}
+
+	if len(archListOut) == 0 {
+		return nil, fmt.Errorf("invalid architecture list; no arches specified")
+	}
+
+	return archListOut, nil
+}
+
+// IsServerOS returns true if cert-manager can be deployed to the given OS on the server side
+func IsServerOS(os string) bool {
+	_, isServer := ServerPlatforms[os]
+	return isServer
+}
+
+// IsClientOS returns true if cert-manager builds client binaries for the given platform
+func IsClientOS(os string) bool {
+	_, isClient := ClientPlatforms[os]
+	return isClient
 }

--- a/pkg/release/platforms_test.go
+++ b/pkg/release/platforms_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestOSListFromString(t *testing.T) {
+	tests := map[string]struct {
+		input        string
+		expectedOSes []string
+		expectErr    bool
+	}{
+		"valid manually specified OSes": {
+			input:        "linux, Windows",
+			expectedOSes: []string{"linux", "windows"},
+			expectErr:    false,
+		},
+		"valid asterisk": {
+			input: "*",
+			// this test will break if we add more OSes but that'll be rare
+			expectedOSes: []string{"linux", "windows", "darwin"},
+			expectErr:    false,
+		},
+		"valid with deduping": {
+			input:        "linux, Windows, LINUX",
+			expectedOSes: []string{"linux", "windows"},
+			expectErr:    false,
+		},
+		"no OSes should error": {
+			input:        "",
+			expectedOSes: nil,
+			expectErr:    true,
+		},
+		"individual invalid OS should error": {
+			input:        "templeos",
+			expectedOSes: nil,
+			expectErr:    true,
+		},
+		"invalid OS among valid should error": {
+			input:        "linux,templeos,windows",
+			expectedOSes: nil,
+			expectErr:    true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			outputSet, err := OSListFromString(test.input)
+
+			if test.expectErr {
+				if err == nil {
+					t.Errorf("expectErr=%v, err=%v", test.expectErr, err)
+				}
+
+				return
+			}
+
+			output := outputSet.List()
+
+			sort.Strings(test.expectedOSes)
+			sort.Strings(output)
+
+			if !reflect.DeepEqual(test.expectedOSes, output) {
+				t.Errorf("expected %#v but got %#v", test.expectedOSes, output)
+				return
+			}
+		})
+	}
+}
+
+func TestArchListFromString(t *testing.T) {
+	tests := map[string]struct {
+		input          string
+		inputOSes      []string
+		expectedArches []string
+		expectErr      bool
+	}{
+		"valid manually specified arches": {
+			input:          "amd64, s390X, ARM64  ",
+			inputOSes:      []string{"linux"},
+			expectedArches: []string{"amd64", "arm64", "s390x"},
+			expectErr:      false,
+		},
+		"valid asterisk": {
+			input:     "*",
+			inputOSes: []string{"linux"},
+			// this test will break if we add more arches but that'll be rare
+			expectedArches: []string{"amd64", "arm", "arm64", "ppc64le", "s390x"},
+			expectErr:      false,
+		},
+		"valid manually specified arches with deduping": {
+			input:          "amd64, s390X, ARM64  ,AMd64",
+			inputOSes:      []string{"linux"},
+			expectedArches: []string{"amd64", "arm64", "s390x"},
+			expectErr:      false,
+		},
+		"no arches should error": {
+			input:          "",
+			inputOSes:      []string{"linux"},
+			expectedArches: nil,
+			expectErr:      true,
+		},
+		"individual invalid arch should error": {
+			input:          "notanarch",
+			inputOSes:      []string{"linux"},
+			expectedArches: nil,
+			expectErr:      true,
+		},
+		"invalid arch among valid should error": {
+			input:          "arm64,notanarch,amd64",
+			inputOSes:      []string{"linux"},
+			expectedArches: nil,
+			expectErr:      true,
+		},
+		"invalid arch for OS should error": {
+			// will break if we add support for s390x on windows, but that's not likely!
+			input:          "s390x",
+			inputOSes:      []string{"windows"},
+			expectedArches: nil,
+			expectErr:      true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			outputSet, err := ArchListFromString(test.input, sets.NewString(test.inputOSes...))
+
+			if test.expectErr {
+				if err == nil {
+					t.Errorf("expectErr=%v, err=%v", test.expectErr, err)
+				}
+
+				return
+			}
+
+			output := outputSet.List()
+
+			sort.Strings(test.expectedArches)
+			sort.Strings(output)
+
+			if !reflect.DeepEqual(test.expectedArches, output) {
+				t.Errorf("expected %#v but got %#v", test.expectedArches, output)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
This should be useful for testing, so that we can, say, only build linux/amd64