### PR TITLE
Fix some fails while staging a release

### DIFF
--- a/cmd/cmrel/cmd/const.go
+++ b/cmd/cmrel/cmd/const.go
@@ -18,4 +18,5 @@ package cmd
 
 // defaultKMSKey is the default signing key; this shouldn't change often so it should be safe enough
 // to hardcode it as a default for the quality-of-life improvement it brings to invoking various cmrel commands
-const defaultKMSKey = "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/versions/1"
+// WARNING: cosign requires a different format for the key; this is the format required by the GCP API but not cosign (which needs "versions" instead of "cryptoKeyVersions")
+const defaultKMSKey = "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/cryptoKeyVersions/1"

--- a/cmd/cmrel/cmd/gcb_stage.go
+++ b/cmd/cmrel/cmd/gcb_stage.go
@@ -146,6 +146,12 @@ func runGCBStage(rootOpts *rootOptions, o *gcbStageOptions) error {
 		return fmt.Errorf("failed to read git ref from repository: %v", err)
 	}
 
+	if o.SigningKMSKey != "" {
+		if _, err := sign.NewGCPKMSKey(o.SigningKMSKey); err != nil {
+			return err
+		}
+	}
+
 	if o.ReleaseVersion != "" {
 		if err := runGit(o.RepoPath, "tag", "-f", o.ReleaseVersion); err != nil {
 			return err
@@ -227,7 +233,12 @@ func runGCBStage(rootOpts *rootOptions, o *gcbStageOptions) error {
 			return nil
 		}
 
-		return sign.CertManagerManifests(ctx, o.SigningKMSKey, path)
+		parsedKey, err := sign.NewGCPKMSKey(o.SigningKMSKey)
+		if err != nil {
+			return err
+		}
+
+		return sign.CertManagerManifests(ctx, parsedKey, path)
 	}
 
 	// add 'manifests' (helm chart, k8s YAML manifests)

--- a/cmd/cmrel/cmd/publish.go
+++ b/cmd/cmrel/cmd/publish.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cert-manager/release/pkg/gcb"
 	"github.com/cert-manager/release/pkg/release"
+	"github.com/cert-manager/release/pkg/sign"
 )
 
 const (
@@ -165,6 +166,12 @@ func runPublish(rootOpts *rootOptions, o *publishOptions) error {
 	gcs, err := storage.NewClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create GCS client: %w", err)
+	}
+
+	if o.SigningKMSKey != "" {
+		if _, err := sign.NewGCPKMSKey(o.SigningKMSKey); err != nil {
+			return err
+		}
 	}
 
 	bucket := release.NewBucket(gcs.Bucket(o.Bucket), release.DefaultBucketPathPrefix, release.BuildTypeRelease)

--- a/cmd/cmrel/cmd/sign_helm.go
+++ b/cmd/cmrel/cmd/sign_helm.go
@@ -49,7 +49,7 @@ var signHelmExample = fmt.Sprintf(`To sign a chart called "mychart.tgz":
 %s %s %s --key "projects/<PROJECT_NAME>/locations/<LOCATION>/keyRings/<KEYRING_NAME>/cryptoKeys/<KEY_NAME>/cryptoKeyVersions/<KEY_VERSION>" --chartpath mychart.tgz`, rootCommand, signCommand, signHelmCommand)
 
 type signHelmOptions struct {
-	// Key is the full name of the GCP KMS key to be used for signing, e.g.
+	// Key is the full name of the GCP KMS key to be used, e.g.
 	// projects/<PROJECT_NAME>/locations/<LOCATION>/keyRings/<KEYRING_NAME>/cryptoKeys/<KEY_NAME>/cryptoKeyVersions/<KEY_VERSION>
 	Key string
 
@@ -95,7 +95,12 @@ func signHelmCmd(rootOpts *rootOptions) *cobra.Command {
 func runSignHelm(rootOpts *rootOptions, o *signHelmOptions) error {
 	ctx := context.Background()
 
-	signatureBytes, err := sign.HelmChart(ctx, o.Key, o.ChartPath)
+	parsedKey, err := sign.NewGCPKMSKey(o.Key)
+	if err != nil {
+		return err
+	}
+
+	signatureBytes, err := sign.HelmChart(ctx, parsedKey, o.ChartPath)
 	if err != nil {
 		return fmt.Errorf("failed to sign: %w", err)
 	}

--- a/cmd/cmrel/cmd/sign_manifests.go
+++ b/cmd/cmrel/cmd/sign_manifests.go
@@ -95,7 +95,12 @@ func signManifestsCmd(rootOpts *rootOptions) *cobra.Command {
 func runSignManifests(rootOpts *rootOptions, o *signManifestsOptions) error {
 	ctx := context.Background()
 
-	err := sign.CertManagerManifests(ctx, o.Key, o.Path)
+	parsedKey, err := sign.NewGCPKMSKey(o.Key)
+	if err != nil {
+		return err
+	}
+
+	err = sign.CertManagerManifests(ctx, parsedKey, o.Path)
 	if err != nil {
 		return fmt.Errorf("failed to complete signing of %q: %w", o.Path, err)
 	}

--- a/cmd/cmrel/cmd/stage.go
+++ b/cmd/cmrel/cmd/stage.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cert-manager/release/pkg/gcb"
 	"github.com/cert-manager/release/pkg/release"
+	"github.com/cert-manager/release/pkg/sign"
 )
 
 const (
@@ -91,6 +92,7 @@ type stageOptions struct {
 
 	// SigningKMSKey is the full name of the GCP KMS key to be used for signing, e.g.
 	// projects/<PROJECT_NAME>/locations/<LOCATION>/keyRings/<KEYRING_NAME>/cryptoKeys/<KEY_NAME>/cryptoKeyVersions/<KEY_VERSION>
+	// This must be set if SkipSigning is not set to true
 	SigningKMSKey string
 
 	// TargetOSes is a comma-separated list of OSes which should be built for in this invocation
@@ -171,6 +173,13 @@ func runStage(rootOpts *rootOptions, o *stageOptions) error {
 		}
 		o.GitRef = ref
 	}
+
+	if o.SigningKMSKey != "" {
+		if _, err := sign.NewGCPKMSKey(o.SigningKMSKey); err != nil {
+			return err
+		}
+	}
+
 	log.Printf("Staging build for %s/%s@%s", o.Org, o.Repo, o.GitRef)
 
 	log.Printf("DEBUG: Loading cloudbuild.yaml file from %q", o.CloudBuildFile)

--- a/gcb/publish/cloudbuild.yaml
+++ b/gcb/publish/cloudbuild.yaml
@@ -74,7 +74,7 @@ substitutions:
   ## Required parameters
   _RELEASE_NAME: ""
   ## Optional/defaulted parameters
-  _KMS_KEY: "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/versions/1"
+  _KMS_KEY: "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/cryptoKeyVersions/1"
   _SKIP_SIGNING: "false"
   _RELEASE_BUCKET: ""
   ## Options controlling the version of the release tooling used in the build.

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -55,7 +55,7 @@ substitutions:
   _RELEASE_VERSION: ""
   _RELEASE_BUCKET: ""
   _PUBLISHED_IMAGE_REPO: quay.io/jetstack
-  _KMS_KEY: "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/versions/1"
+  _KMS_KEY: "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/cryptoKeyVersions/1"
   _SKIP_SIGNING: "false"
   # gcr.io/cloud-builders/bazel does not have tagged images only image digests,
   # so we have to manually find an image with the desired version.

--- a/pkg/sign/cosign/cosign.go
+++ b/pkg/sign/cosign/cosign.go
@@ -18,21 +18,17 @@ package cosign
 
 import (
 	"context"
-	"strings"
 
 	"github.com/cert-manager/release/pkg/shell"
+	"github.com/cert-manager/release/pkg/sign"
 )
 
 // Sign calls out to cosign to sign a given container using the provided GCP key.
-func Sign(ctx context.Context, containers []string, key string) error {
-	if !strings.HasPrefix(key, "gcpkms://") {
-		key = "gcpkms://" + key
-	}
-
+func Sign(ctx context.Context, containers []string, key sign.GCPKMSKey) error {
 	args := append([]string{
 		"sign",
 		"-key",
-		key,
+		key.CosignFormat(),
 	}, containers...)
 
 	return shell.Command(ctx, "", "cosign", args...)

--- a/pkg/sign/helm.go
+++ b/pkg/sign/helm.go
@@ -26,7 +26,7 @@ import (
 
 // HelmChart signs a given packaged helm chart (usually a .tgz file) using the given
 // KMS key, returning the human-readable signature bytes.
-func HelmChart(ctx context.Context, key string, chartPath string) ([]byte, error) {
+func HelmChart(ctx context.Context, key GCPKMSKey, chartPath string) ([]byte, error) {
 	signatory, err := signatoryFromKMS(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create KMS signer: %w", err)
@@ -51,7 +51,7 @@ func HelmChart(ctx context.Context, key string, chartPath string) ([]byte, error
 
 // signatoryFromKMS creates a Helm Signatory backed by a KMS key. The Signatory can then
 // be used to sign helm charts, but won't also be usable for validating signatures.
-func signatoryFromKMS(ctx context.Context, key string) (*helmsign.Signatory, error) {
+func signatoryFromKMS(ctx context.Context, key GCPKMSKey) (*helmsign.Signatory, error) {
 	entity, _, err := deriveEntity(ctx, key)
 	if err != nil {
 		return nil, err

--- a/pkg/sign/kmskey.go
+++ b/pkg/sign/kmskey.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sign
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var keyRegex = regexp.MustCompile(`^projects/([^/]+)/locations/([^/]+)/keyRings/([^/]+)/cryptoKeys/([^/]+)/cryptoKeyVersions/([^/]+)$`)
+
+// GCPKMSKey holds a GCP KMS key, easily serializable to either GCP format ('cryptoKeyVersions') or cosign format ('versions')
+type GCPKMSKey struct {
+	projectID  string
+	locationID string
+	keyRing    string
+	keyName    string
+	version    string
+}
+
+// NewGCPKMSKey parses and validates an input KMS key. The accepted format is that provided when copying the resource name in the GCP console.
+// The format provided by GCP is distinct from the format required by cosign; notably
+// GCP uses "cryptoKeyVersions" and cosign requires "versions".
+func NewGCPKMSKey(raw string) (GCPKMSKey, error) {
+	v := keyRegex.FindStringSubmatch(raw)
+
+	if len(v) != 6 {
+		return GCPKMSKey{}, fmt.Errorf("invalid GCP KMS format: %q", raw)
+	}
+
+	projectID, locationID, keyRing, keyName, version := v[1], v[2], v[3], v[4], v[5]
+
+	return GCPKMSKey{
+		projectID:  projectID,
+		locationID: locationID,
+		keyRing:    keyRing,
+		keyName:    keyName,
+		version:    version,
+	}, nil
+}
+
+// String returns the key in GCP format
+func (g GCPKMSKey) String() string {
+	return g.GCPFormat()
+}
+
+// GCPFormat returns the key verbatim, which will be the format required for GCP actions
+func (g GCPKMSKey) GCPFormat() string {
+	return fmt.Sprintf(
+		"projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s/cryptoKeyVersions/%s",
+		g.projectID,
+		g.locationID,
+		g.keyRing,
+		g.keyName,
+		g.version,
+	)
+}
+
+// CosignFormat returns the key in the correct format for cosign, which uses "versions" instead of "cryptoKeyVersions". Also prepends the gcpkms scheme
+func (g GCPKMSKey) CosignFormat() string {
+	return fmt.Sprintf(
+		"gcpkms://projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s/versions/%s",
+		g.projectID,
+		g.locationID,
+		g.keyRing,
+		g.keyName,
+		g.version,
+	)
+}

--- a/pkg/sign/kmskey_test.go
+++ b/pkg/sign/kmskey_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sign
+
+import "testing"
+
+func TestGCPKMSKey(t *testing.T) {
+	tests := map[string]struct {
+		input             string
+		expectedCosignKey string
+		shouldError       bool
+	}{
+		"parses GCP formatted key": {
+			input:             "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/cryptoKeyVersions/1",
+			expectedCosignKey: "gcpkms://projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/versions/1",
+			shouldError:       false,
+		},
+		"doesn't parse cosign formatted key": {
+			input:       "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/versions/1",
+			shouldError: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			key, err := NewGCPKMSKey(test.input)
+
+			if (err != nil) != test.shouldError {
+				t.Errorf("shouldError=%v, err=%v", test.shouldError, err)
+				return
+			}
+
+			if test.shouldError {
+				return
+			}
+
+			// input format _is_ GCP format
+			if key.GCPFormat() != test.input {
+				t.Errorf("wanted GCP formatted key %q but got %q", test.input, key.GCPFormat())
+			}
+
+			if key.CosignFormat() != test.expectedCosignKey {
+				t.Errorf("wanted cosign formatted key %q but got %q", test.expectedCosignKey, key.CosignFormat())
+			}
+		})
+	}
+}

--- a/pkg/sign/manifest.go
+++ b/pkg/sign/manifest.go
@@ -37,11 +37,7 @@ const manifestLocation = "deploy/chart/cert-manager.tgz"
 // the helm chart located at "deploy/chart/cert-manager.tgz" is signed, and a
 // signature "deploy/chart/cert-manager.tgz.prov" will be added.
 // The cert-manifests.tar.gz file is changed in-place.
-func CertManagerManifests(ctx context.Context, key string, path string) error {
-	if key == "" {
-		return fmt.Errorf("can't sign manifests without a signing key specified")
-	}
-
+func CertManagerManifests(ctx context.Context, key GCPKMSKey, path string) error {
 	// 1. Create temp dir for chart archive to be extracted to
 	// (Helm signing requires a filename, not a reader, so we have to write to disk here)
 	tmpDest, err := os.MkdirTemp("", "cmrel-extracted-manifests-")


### PR DESCRIPTION
Each commit can be individually reviewed

1. A typo in a gcp definition file, simple
2. Adds an explicit GCPKMSKey type parsed from a raw string. cosign needs the key in a different format, and this type makes it easier to get the correct format in the correct place.

It would be possible to accept both types of key as input, but I've decided to stick to just what's provided by GCP