### PR TITLE
Pass a version number when signing manifests

### DIFF
--- a/cmd/cmrel/cmd/gcb_stage.go
+++ b/cmd/cmrel/cmd/gcb_stage.go
@@ -238,7 +238,7 @@ func runGCBStage(rootOpts *rootOptions, o *gcbStageOptions) error {
 			return err
 		}
 
-		return sign.CertManagerManifests(ctx, parsedKey, path)
+		return sign.CertManagerManifests(ctx, parsedKey, path, o.ReleaseVersion)
 	}
 
 	// add 'manifests' (helm chart, k8s YAML manifests)


### PR DESCRIPTION
The name of the chart to be signed is included into the generated prov file and needs to match the name the chart is eventually consumed under, which means when we write the temporary chart we need to change its name to generate the signature.

Ideally, the chart would probably have the correct name when it's built, but this approach works with cert-manager as it current builds things