### PR TITLE
Adds support for cmctl release target

### DIFF
--- a/cmd/cmrel/cmd/gcb_publish.go
+++ b/cmd/cmrel/cmd/gcb_publish.go
@@ -426,7 +426,7 @@ func pushGitHubRelease(ctx context.Context, o *gcbPublishOptions, rel *release.U
 			return fmt.Errorf("failed to open manifest file to be uploaded: %v", err)
 		}
 		defer f.Close()
-		ctlBinariesByName[fmt.Sprintf("kubectl-cert_manager-%s-%s.tar.gz", binaryTar.OS(), binaryTar.Architecture())] = f
+		ctlBinariesByName[fmt.Sprintf("%s-%s-%s.tar.gz", binaryTar.Name(), binaryTar.OS(), binaryTar.Architecture())] = f
 	}
 
 	log.Printf("Creating a draft GitHub release %q in repository %s/%s", rel.ReleaseVersion, o.PublishedGitHubOrg, o.PublishedGitHubRepo)

--- a/cmd/cmrel/cmd/gcb_stage.go
+++ b/cmd/cmrel/cmd/gcb_stage.go
@@ -217,11 +217,13 @@ func runGCBStage(rootOpts *rootOptions, o *gcbStageOptions) error {
 			}
 
 			if release.IsClientOS(osVariant) {
-				// add an artifact for the os and arch specific 'ctl' release tarball
-				clientArtifactName := fmt.Sprintf("cert-manager-kubectl-cert_manager-%s-%s.tar.gz", osVariant, arch)
-				// Add the arch-specific .tar.gz file to the list of artifacts
-				if err := appendArtifact(&artifacts, o.RepoPath, clientArtifactName, osVariant, arch); err != nil {
-					return err
+				// add an artifact for the os and arch specific 'cmctl' and 'kubectl-cert_manager' release tarball
+				for _, kind := range []string{"kubectl-cert_manager", "cmctl"} {
+					clientArtifactName := fmt.Sprintf("cert-manager-%s-%s-%s.tar.gz", kind, osVariant, arch)
+					// Add the arch-specific .tar.gz file to the list of artifacts
+					if err := appendArtifact(&artifacts, o.RepoPath, clientArtifactName, osVariant, arch); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/pkg/release/binaries/tar.go
+++ b/pkg/release/binaries/tar.go
@@ -24,9 +24,12 @@ type Tar struct {
 	// os and arch of the binary. This must be provided at instantiation time
 	// and cannot be determined by inspecting the tar file.
 	os, arch string
+
+	// name is the base name of the binary, (e.g. `cmctl`).
+	name string
 }
 
-func NewFile(path, osStr, arch string) (*Tar, error) {
+func NewFile(name, path, osStr, arch string) (*Tar, error) {
 	return &Tar{
 		path: path,
 		os:   osStr,
@@ -44,4 +47,8 @@ func (i *Tar) OS() string {
 
 func (i *Tar) Architecture() string {
 	return i.arch
+}
+
+func (i *Tar) Name() string {
+	return i.name
 }

--- a/pkg/release/validation/validate.go
+++ b/pkg/release/validation/validate.go
@@ -51,7 +51,7 @@ func ValidateUnpackedRelease(opts Options, rel *release.Unpacked) ([]string, err
 		}
 	}
 	if len(rel.CtlBinaryBundles) == 0 {
-		violations = append(violations, fmt.Sprintf("No kubectl plugin binaries found in release - this is probably an error!"))
+		violations = append(violations, fmt.Sprintf("No ctl binaries found in release - this is probably an error!"))
 	}
 	return violations, nil
 }


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

This PR will release binaries for both `kubectl-cert_manager`, as well as `cmctl`.

/assign @jakexks 