### PR TITLE
Commit helm chart and prov in one commit

### DIFF
--- a/pkg/release/helm/github_client.go
+++ b/pkg/release/helm/github_client.go
@@ -38,17 +38,17 @@ type PullRequestClient interface {
 type GitClient interface {
 	GetRef(ctx context.Context, owner string, repo string, ref string) (*github.Reference, *github.Response, error)
 	CreateRef(ctx context.Context, owner string, repo string, ref *github.Reference) (*github.Reference, *github.Response, error)
+	CreateTree(ctx context.Context, owner string, repo string, baseTree string, entries []*github.TreeEntry) (*github.Tree, *github.Response, error)
+	CreateCommit(ctx context.Context, owner string, repo string, commit *github.Commit) (*github.Commit, *github.Response, error)
+	UpdateRef(ctx context.Context, owner string, repo string, ref *github.Reference, force bool) (*github.Reference, *github.Response, error)
+	CreateBlob(ctx context.Context, owner string, repo string, blob *github.Blob) (*github.Blob, *github.Response, error)
 }
 
 type RepositoriesClient interface {
-	// CreateFile creates a new file in a repository at the given path and returns
-	// the commit and file metadata.
-	//
-	// GitHub API docs: https://developer.github.com/v3/repos/contents/#create-a-file
-	CreateFile(ctx context.Context, owner, repo, path string, opt *github.RepositoryContentFileOptions) (*github.RepositoryContentResponse, *github.Response, error)
 	// GetPermissionLevel retrieves the specific permission level a collaborator has for a given repository.
 	// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/repos/#get-repository-permissions-for-a-user
 	GetPermissionLevel(ctx context.Context, owner, repo, user string) (*github.RepositoryPermissionLevel, *github.Response, error)
+	GetCommit(ctx context.Context, owner, repo, sha string) (*github.RepositoryCommit, *github.Response, error)
 }
 
 type UsersClient interface {


### PR DESCRIPTION
This addresses a race condition caused by github actions in the chart repo

See (closed source) PR for example of this being used successfully: https://github.com/jetstack/jetstack-charts/pull/79

NB: the "old" CreateFile API call had a lot of sugar to hide the complexities of committing files. Unfortunately it doesn't seem like there's a direct equivalent that we can use for multiple files, so the "new" way of doing the commit is significantly more complex to look at.

It's based largely on a go-github example, although there's some additional work needed to handle binaries: https://github.com/google/go-github/blob/master/example/commitpr/main.go