### PR TITLE
Update cmrel to use the new cert-manager organization on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Flags:
       --cloudbuild string             The path to the cloudbuild.yaml file used to perform the cert-manager crossbuild. The default value assumes that this tool is run from the root of the release repository. (default "./gcb/stage/cloudbuild.yaml")
       --git-ref string                The git commit ref of cert-manager that should be staged.
   -h, --help                          help for stage
-      --org string                    Name of the GitHub org to fetch cert-manager sources from. (default "jetstack")
+      --org string                    Name of the GitHub org to fetch cert-manager sources from. (default "cert-manager")
       --project string                The GCP project to run the GCB build jobs in. (default "cert-manager-release")
       --published-image-repo string   The docker image repository set when building the release. (default "quay.io/jetstack")
       --release-version string        Optional release version override used to force the version strings used during the release to a specific value.

--- a/cmd/cmrel/cmd/stage.go
+++ b/cmd/cmrel/cmd/stage.go
@@ -104,7 +104,7 @@ type stageOptions struct {
 
 func (o *stageOptions) AddFlags(fs *flag.FlagSet, markRequired func(string)) {
 	fs.StringVar(&o.Bucket, "bucket", release.DefaultBucketName, "The name of the GCS bucket to stage the release to.")
-	fs.StringVar(&o.Org, "org", "jetstack", "Name of the GitHub org to fetch cert-manager sources from.")
+	fs.StringVar(&o.Org, "org", "cert-manager", "Name of the GitHub org to fetch cert-manager sources from.")
 	fs.StringVar(&o.Repo, "repo", "cert-manager", "Name of the GitHub repo to fetch cert-manager sources from.")
 	fs.StringVar(&o.Branch, "branch", "master", "The git branch to build the release from. If --git-ref is not specified, the HEAD of this branch will be looked up on GitHub.")
 	fs.StringVar(&o.GitRef, "git-ref", "", "The git commit ref of cert-manager that should be staged.")

--- a/gcb/publish/cloudbuild.yaml
+++ b/gcb/publish/cloudbuild.yaml
@@ -58,7 +58,7 @@ steps:
 
 ## Build and push the release artifacts
 - name: gcr.io/cloud-builders/docker:19.03.8
-  dir: "go/src/github.com/jetstack/cert-manager"
+  dir: "go/src/github.com/cert-manager/cert-manager"
   entrypoint: /workspace/go/bin/cmrel
   secretEnv:
   - GITHUB_TOKEN

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -4,7 +4,7 @@ steps:
 
 ## Clone & checkout the cert-manager repository
 - name: gcr.io/cloud-builders/git
-  dir: "go/src/github.com/jetstack/cert-manager"
+  dir: "go/src/github.com/cert-manager/cert-manager"
   entrypoint: bash
   args:
   - -c
@@ -25,7 +25,7 @@ steps:
 
 ## Build and push the release artifacts
 - name: 'gcr.io/cloud-builders/bazel@${_BAZEL_IMAGE_SHA}'
-  dir: "go/src/github.com/jetstack/cert-manager"
+  dir: "go/src/github.com/cert-manager/cert-manager"
   entrypoint: /workspace/go/bin/cmrel
   args:
   - gcb
@@ -51,7 +51,7 @@ substitutions:
   ## Required parameters
   _CM_REF: ""
   ## Optional/defaulted parameters
-  _CM_REPO: https://github.com/jetstack/cert-manager.git
+  _CM_REPO: https://github.com/cert-manager/cert-manager.git
   _RELEASE_VERSION: ""
   _RELEASE_BUCKET: ""
   _PUBLISHED_IMAGE_REPO: quay.io/jetstack

--- a/pkg/release/consts.go
+++ b/pkg/release/consts.go
@@ -48,7 +48,7 @@ const (
 
 	// DefaultGitHubOrg is the default organisation containing the cert-manager
 	// repository.
-	DefaultGitHubOrg = "jetstack"
+	DefaultGitHubOrg = "cert-manager"
 
 	// DefaultGitHubRepo is the default repository containing the cert-manager
 	// code.

--- a/test/presubmit.sh
+++ b/test/presubmit.sh
@@ -33,10 +33,10 @@ if [ ! -z $SIGNING_KEY ]; then
 fi
 
 # clone cert-manager @ master
-echo "+++ Cloning jetstack/cert-manager repository"
+echo "+++ Cloning cert-manager/cert-manager repository"
 tmpdir="$(mktemp -d)"
 trap "rm -rf ${tmpdir}" EXIT
-git clone https://github.com/jetstack/cert-manager.git "${tmpdir}"
+git clone https://github.com/cert-manager/cert-manager.git "${tmpdir}"
 
 echo "+++ Running 'gcb stage' command"
 $CMREL gcb stage \


### PR DESCRIPTION
Following the move from github.com/jetstack/cert-manager to github.com/cert-manager/cert-manager

* https://github.com/cert-manager/cert-manager/issues/4824