### PR TITLE
Re-enable container signing and bump cosign version

### DIFF
--- a/cmd/cmrel/cmd/gcb_publish.go
+++ b/cmd/cmrel/cmd/gcb_publish.go
@@ -528,13 +528,9 @@ func pushContainerImages(ctx context.Context, o *gcbPublishOptions, rel *release
 		log.Printf("Pushed multi-arch manifest list %q", manifestListName)
 	}
 
-	// TODO: since cert-manager images are currently pushed to quay.io, we can't actually sign
-	// the images since quay doesn't support cosign signatures. when it's upgraded to 3.6, we can
-	// uncomment this and sign.
-	// see: https://github.com/sigstore/cosign/issues/40#issuecomment-833217878
-	// if err := signRegistryContent(ctx, o, pushedContent); err != nil {
-	// 	return fmt.Errorf("failed to sign images: %w", err)
-	// }
+	if err := signRegistryContent(ctx, o, pushedContent); err != nil {
+		return fmt.Errorf("failed to sign images: %w", err)
+	}
 
 	return nil
 }

--- a/gcb/publish/cloudbuild.yaml
+++ b/gcb/publish/cloudbuild.yaml
@@ -108,5 +108,5 @@ substitutions:
   _TAG_RELEASE_NAME: ""
   ## Cosign details
   _COSIGN_REPO_URL: https://github.com/sigstore/cosign
-  _COSIGN_REPO_REF: "v1.2.1"
+  _COSIGN_REPO_REF: "v1.5.2"
   _COSIGN_PATH: "/workspace/go/bin/cosign"


### PR DESCRIPTION
Now that quay supports signing, we can enable container signing again!