### PR TITLE
Save makestage artifacts at the same location stage artifacts are saved

### DIFF
--- a/cmd/cmrel/cmd/makestage.go
+++ b/cmd/cmrel/cmd/makestage.go
@@ -127,6 +127,8 @@ func makeStageCmd(rootOpts *rootOptions) *cobra.Command {
 }
 
 func runMakeStage(rootOpts *rootOptions, o *makeStageOptions) error {
+	ctx := context.Background()
+
 	if o.SigningKMSKey != "" {
 		if _, err := sign.NewGCPKMSKey(o.SigningKMSKey); err != nil {
 			return err
@@ -145,13 +147,21 @@ func runMakeStage(rootOpts *rootOptions, o *makeStageOptions) error {
 		build.Options = &cloudbuild.BuildOptions{MachineType: "n1-highcpu-32"}
 	}
 
+	gitRef, err := release.LookupRefSHA(o.Org, o.Repo, o.Ref)
+	if err != nil {
+		return fmt.Errorf("error looking up git commit ref: %w", err)
+	}
+
+	outputDir := release.BucketPathForRelease(release.DefaultBucketPathPrefix, release.BuildTypeRelease, o.Ref, gitRef)
+
+	outputGCSURL := fmt.Sprintf("gs://%s/%s", o.Bucket, outputDir)
+
 	build.Substitutions["_CM_REF"] = o.Ref
 	build.Substitutions["_CM_REPO"] = fmt.Sprintf("https://github.com/%s/%s.git", o.Org, o.Repo)
-	build.Substitutions["_RELEASE_BUCKET"] = o.Bucket
+	build.Substitutions["_OUTPUT_GCS_URL"] = outputGCSURL
 	build.Substitutions["_KMS_KEY"] = o.SigningKMSKey
 
 	log.Printf("DEBUG: building google cloud build API client")
-	ctx := context.Background()
 	svc, err := cloudbuild.NewService(ctx)
 	if err != nil {
 		return fmt.Errorf("error building google cloud build API client: %w", err)
@@ -177,10 +187,10 @@ func runMakeStage(rootOpts *rootOptions, o *makeStageOptions) error {
 
 	if build.Status != gcb.Success {
 		log.Printf("An error occurred building the release. Check the log files for more information: %s", build.LogUrl)
-		return fmt.Errorf("building release tarballs failed")
+		return fmt.Errorf("building release with ref %q failed", o.Ref)
 	}
 
-	log.Printf("Release build complete for ref %s", o.Ref)
+	log.Printf("Release build complete for %s/%s@%s - artifacts available at: %s", o.Org, o.Repo, o.Ref, outputGCSURL)
 
 	return nil
 }

--- a/gcb/makestage/cloudbuild.yaml
+++ b/gcb/makestage/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
     git clone "${_CM_REPO}" . && git checkout "${_CM_REF}"
 
 ## Build release artifacts and push to a bucket
-- name: 'eu.gcr.io/jetstack-build-infra-images/bazelbuild:${_IMAGE_TAG}'
+- name: 'eu.gcr.io/jetstack-build-infra-images/bazelbuild:${_BUILDER_IMAGE_TAG}'
   dir: "go/src/github.com/cert-manager/cert-manager"
   entrypoint: bash
   args:
@@ -21,26 +21,23 @@ steps:
   - |
     set -eu -o pipefail
     apt-get install -y jq
-    export RELEASE_NAME="$(git describe --tags)-$(git rev-parse HEAD)"
-    export RELEASE_BUCKET_PATH="gs://${_RELEASE_BUCKET}/release/$$RELEASE_NAME"
     make vendor-go
     make CMREL_KEY="${_KMS_KEY}" -j16 release
-    gsutil -m cp ./bin/release/* $$RELEASE_BUCKET_PATH
-    echo "Wrote $$RELEASE_NAME to $$RELEASE_BUCKET_PATH"
+    gsutil -m cp ./bin/release/* ${_OUTPUT_GCS_URL}
+    echo "Wrote to ${_OUTPUT_GCS_URL}"
 
 tags:
 - "cert-manager-release-makestage"
 - "ref-${_CM_REF}"
 
 substitutions:
-  ## Required parameters
   _CM_REF: "master"
-  ## Optional/defaulted parameters
-  _CM_REPO: https://github.com/cert-manager/cert-manager.git
+  _CM_REPO: "https://github.com/cert-manager/cert-manager.git"
   _KMS_KEY: "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/cryptoKeyVersions/1"
+  _OUTPUT_GCS_URL: ""
   # gcr.io/cloud-builders/bazel does not have tagged images only image digests,
   # so we have to manually find an image with the desired version.
-  _IMAGE_TAG: "20210831-4cf7b0b-4.2.1"
+  _BUILDER_IMAGE_TAG: "20210831-4cf7b0b-4.2.1"
 
 options:
   machineType: n1-highcpu-32


### PR DESCRIPTION
Also does some cleanup of makestage, simplifies things, and adds output of the GCS target path in console

Part of the migration to make: https://github.com/cert-manager/cert-manager/issues/4712