### PR TITLE
Use `make publish-release` / update builder image

### DIFF
--- a/cmd/cmrel/cmd/makestage.go
+++ b/cmd/cmrel/cmd/makestage.go
@@ -152,13 +152,9 @@ func runMakeStage(rootOpts *rootOptions, o *makeStageOptions) error {
 		return fmt.Errorf("error looking up git commit ref: %w", err)
 	}
 
-	outputDir := release.BucketPathForRelease(release.DefaultBucketPathPrefix, release.BuildTypeRelease, o.Ref, gitRef)
-
-	outputGCSURL := fmt.Sprintf("gs://%s/%s", o.Bucket, outputDir)
-
 	build.Substitutions["_CM_REF"] = o.Ref
 	build.Substitutions["_CM_REPO"] = fmt.Sprintf("https://github.com/%s/%s.git", o.Org, o.Repo)
-	build.Substitutions["_OUTPUT_GCS_URL"] = outputGCSURL
+	build.Substitutions["_RELEASE_TARGET_BUCKET"] = o.Bucket
 	build.Substitutions["_KMS_KEY"] = o.SigningKMSKey
 
 	log.Printf("DEBUG: building google cloud build API client")
@@ -189,6 +185,9 @@ func runMakeStage(rootOpts *rootOptions, o *makeStageOptions) error {
 		log.Printf("An error occurred building the release. Check the log files for more information: %s", build.LogUrl)
 		return fmt.Errorf("building release with ref %q failed", o.Ref)
 	}
+
+	outputDir := release.BucketPathForRelease(release.DefaultBucketPathPrefix, release.BuildTypeRelease, o.Ref, gitRef)
+	outputGCSURL := fmt.Sprintf("gs://%s/%s", o.Bucket, outputDir)
 
 	log.Printf("Release build complete for %s/%s@%s - artifacts available at: %s", o.Org, o.Repo, o.Ref, outputGCSURL)
 

--- a/gcb/makestage/cloudbuild.yaml
+++ b/gcb/makestage/cloudbuild.yaml
@@ -21,9 +21,8 @@ steps:
   - |
     set -eu -o pipefail
     make vendor-go
-    make CMREL_KEY="${_KMS_KEY}" -j16 release
-    gsutil -m cp ./bin/release/* ${_OUTPUT_GCS_URL}
-    echo "Wrote to ${_OUTPUT_GCS_URL}"
+    make CMREL_KEY="${_KMS_KEY}" RELEASE_TARGET_BUCKET="${_RELEASE_TARGET_BUCKET}" -j16 upload-release
+    echo "Wrote to ${_RELEASE_TARGET_BUCKET}"
 
 tags:
 - "cert-manager-release-makestage"
@@ -33,7 +32,7 @@ substitutions:
   _CM_REF: "master"
   _CM_REPO: "https://github.com/cert-manager/cert-manager.git"
   _KMS_KEY: "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/cryptoKeyVersions/1"
-  _OUTPUT_GCS_URL: ""
+  _RELEASE_TARGET_BUCKET: "cert-manager-release"
   _BUILDER_IMAGE_TAG: "20220512-b6ea825-4.2.1"
 
 options:

--- a/gcb/makestage/cloudbuild.yaml
+++ b/gcb/makestage/cloudbuild.yaml
@@ -20,7 +20,6 @@ steps:
   - -c
   - |
     set -eu -o pipefail
-    apt-get install -y jq
     make vendor-go
     make CMREL_KEY="${_KMS_KEY}" -j16 release
     gsutil -m cp ./bin/release/* ${_OUTPUT_GCS_URL}
@@ -37,7 +36,7 @@ substitutions:
   _OUTPUT_GCS_URL: ""
   # gcr.io/cloud-builders/bazel does not have tagged images only image digests,
   # so we have to manually find an image with the desired version.
-  _BUILDER_IMAGE_TAG: "20210831-4cf7b0b-4.2.1"
+  _BUILDER_IMAGE_TAG: "20220512-b6ea825-4.2.1"
 
 options:
   machineType: n1-highcpu-32

--- a/gcb/makestage/cloudbuild.yaml
+++ b/gcb/makestage/cloudbuild.yaml
@@ -34,8 +34,6 @@ substitutions:
   _CM_REPO: "https://github.com/cert-manager/cert-manager.git"
   _KMS_KEY: "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/cryptoKeyVersions/1"
   _OUTPUT_GCS_URL: ""
-  # gcr.io/cloud-builders/bazel does not have tagged images only image digests,
-  # so we have to manually find an image with the desired version.
   _BUILDER_IMAGE_TAG: "20220512-b6ea825-4.2.1"
 
 options:


### PR DESCRIPTION
Can be merged now that following prerequisite PRs have both merged:

- https://github.com/cert-manager/cert-manager/pull/5209
- https://github.com/cert-manager/cert-manager/pull/5205

This PR has a few commits, each of which is self-contained and individually reviewable.

The first removes our manual installation of `jq` since we added that to the `bazelbuild` image in https://github.com/jetstack/testing/pull/68.

The second removes a comment which wasn't really relevant to this file (I think it was copy-pasted).

The third uses the `make publish-release` target that was added to the cert-manager repo instead of the manual `gsutil` commands we used to release 1.8 originally.