### PR TITLE
Reduce work + simplify output

### DIFF
--- a/cmd/cmrel/cmd/makestage.go
+++ b/cmd/cmrel/cmd/makestage.go
@@ -147,11 +147,6 @@ func runMakeStage(rootOpts *rootOptions, o *makeStageOptions) error {
 		build.Options = &cloudbuild.BuildOptions{MachineType: "n1-highcpu-32"}
 	}
 
-	gitRef, err := release.LookupRefSHA(o.Org, o.Repo, o.Ref)
-	if err != nil {
-		return fmt.Errorf("error looking up git commit ref: %w", err)
-	}
-
 	build.Substitutions["_CM_REF"] = o.Ref
 	build.Substitutions["_CM_REPO"] = fmt.Sprintf("https://github.com/%s/%s.git", o.Org, o.Repo)
 	build.Substitutions["_RELEASE_TARGET_BUCKET"] = o.Bucket
@@ -186,10 +181,7 @@ func runMakeStage(rootOpts *rootOptions, o *makeStageOptions) error {
 		return fmt.Errorf("building release with ref %q failed", o.Ref)
 	}
 
-	outputDir := release.BucketPathForRelease(release.DefaultBucketPathPrefix, release.BuildTypeRelease, o.Ref, gitRef)
-	outputGCSURL := fmt.Sprintf("gs://%s/%s", o.Bucket, outputDir)
-
-	log.Printf("Release build complete for %s/%s@%s - artifacts available at: %s", o.Org, o.Repo, o.Ref, outputGCSURL)
+	log.Printf("Release build complete for %s/%s@%s", o.Org, o.Repo, o.Ref)
 
 	return nil
 }


### PR DESCRIPTION
The path to which we write staged releases is now simpler for tagged
releases, and the release process has been simplified to reflect this.

We no longer need to calculate this path, nor do we need to output it.
A maintainer performing a release can simply use their `RELEASE_VERSION`
variable which they already have.