### PR TITLE
Enable dind for trivy jobs

### DIFF
--- a/pkg/prowgen/generators.go
+++ b/pkg/prowgen/generators.go
@@ -287,6 +287,7 @@ func TrivyTest(containerName string) *Job {
 		fmt.Sprintf("Runs a Trivy scan against the %s container", containerName),
 		addServiceAccountLabel,
 		addMakeVolumesLabel,
+		addDindLabel,
 		addMaxConcurrency(2),
 	)
 


### PR DESCRIPTION
Tests are [currently failing](https://testgrid.k8s.io/cert-manager-periodics-master#ci-cert-manager-master-trivy-test-controller) because of a lack of docker.