### PR TITLE
Option to write generated prow config, and automatically create pull request against jetstack/testing

### DIFF
--- a/.github/workflows/update-prow-config.yaml
+++ b/.github/workflows/update-prow-config.yaml
@@ -1,0 +1,46 @@
+# When a cert-manager/release PR is merged, this workflow generates prow
+# testing config for a set of cert-manager branches, and if out-of-sync with
+# jetstack/testing master, will create a new PR with those changes.
+#
+# We use the https://github.com/peter-evans/create-pull-request action to
+# create a pull request if it is needed.
+
+name: Update jetstack/testing with cert-manager/cert-manager prow test config.
+on:
+  push:
+    branches-ignore:
+      - main
+jobs:
+  update-prow-config:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: install_go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+    - name: checkout
+      uses: actions/checkout@v3
+      with:
+        path: release
+    - name: checkout
+      uses: actions/checkout@v3
+      with:
+        repository: jetstack/testing
+        path: testing
+    - name: Generate prow config.
+      run: |
+        cd release && go install ./cmd/cmrel && cd -
+        cd testing/config/jobs/cert-manager/cert-manager
+        # Preserve hand-rolled bazel tests and READMEs
+        find . ! \( -name '*bazel*' -o -name '*.md' \) -type f -exec rm -rf {} +
+        # Delete empty directories
+        find . -empty -type d -delete
+        cmrel generate-prow  --branch '*' -o file
+      - uses: peter-evans/create-pull-request@v4
+        id: cpr
+        name: Create Pull Request is there are changes
+      - name: Check outputs
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/update-prow-config.yaml
+++ b/.github/workflows/update-prow-config.yaml
@@ -18,15 +18,18 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.19
-    - name: checkout
+
+    - name: checkout cert-manager/release
       uses: actions/checkout@v3
       with:
         path: release
-    - name: checkout
+
+    - name: checkout jetstack/testing
       uses: actions/checkout@v3
       with:
         repository: jetstack/testing
         path: testing
+
     - name: Generate prow config.
       run: |
         cd release && go install ./cmd/cmrel && cd -
@@ -36,11 +39,13 @@ jobs:
         # Delete empty directories
         find . -empty -type d -delete
         cmrel generate-prow  --branch '*' -o file
-      - uses: peter-evans/create-pull-request@v4
-        id: cpr
-        name: Create Pull Request is there are changes
-      - name: Check outputs
-        if: ${{ steps.cpr.outputs.pull-request-number }}
-        run: |
-          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+
+    - name: create pull request if there are changes
+      uses: peter-evans/create-pull-request@v4
+      id: cpr
+
+    - name: check outputs
+      if: ${{ steps.cpr.outputs.pull-request-number }}
+      run: |
+        echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+        echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/update-prow-config.yaml
+++ b/.github/workflows/update-prow-config.yaml
@@ -8,8 +8,8 @@
 name: Update jetstack/testing with cert-manager/cert-manager prow test config.
 on:
   push:
-    branches-ignore:
-      - main
+    branches:
+      - master
 jobs:
   update-prow-config:
     runs-on: ubuntu-22.04

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,36 @@
+name: verify
+on:
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  show-prow-config-changes:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: install_go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+
+    - name: checkout cert-manager/release
+      uses: actions/checkout@v3
+      with:
+        path: release
+
+    - name: checkout jetstack/testing
+      uses: actions/checkout@v3
+      with:
+        repository: jetstack/testing
+        path: testing
+
+    - name: Generate prow config and show changes
+      run: |
+        cd release && go install ./cmd/cmrel && cd -
+        cd testing/config/jobs/cert-manager/cert-manager
+        # Preserve hand-rolled bazel tests and READMEs
+        find . ! \( -name '*bazel*' -o -name '*.md' \) -type f -exec rm -rf {} +
+        # Delete empty directories
+        find . -empty -type d -delete
+        cmrel generate-prow  --branch '*' -o file
+        echo ">>> Please see the changes this PR will make to cert-manager prow config:"
+        git add . && git --no-pager diff HEAD

--- a/prowspecs/specs.go
+++ b/prowspecs/specs.go
@@ -173,14 +173,14 @@ func (m *BranchSpec) GenerateJobFile() *prowgen.JobFile {
 }
 
 // KnownBranches returns a list of all branches which have been configured here
-func KnownBranches() string {
+func KnownBranches() []string {
 	var availableBranches []string
 
 	for branch, _ := range knownBranches {
 		availableBranches = append(availableBranches, branch)
 	}
 
-	return strings.Join(availableBranches, ", ")
+	return availableBranches
 }
 
 // SpecForBranch returns a spec for the named branch, if it exists


### PR DESCRIPTION
This PR adds a new flag `--output` to `generate-prow`. The default `stdout` value prints to stdout as it does currently. `file` will write the prow config to a directory and file in form `<branch>/cert-manager-<branch>.yaml` to mimic the [existing path structure](https://github.com/jetstack/testing/tree/master/config/jobs/cert-manager/cert-manager).

The `branches` flag now also accepts a value of `*` which will loop over all existing known branches.

---

A github workflow is added which (hopefully) runs the generate command when a `cert-manager/release` PR is merged. If the output is different to what is currently in `jetstack/testing`, then a PR will be opened with the changes.

This new workflow uses `peter-evans/create-pull-request@v4`. I don't know how we using a third party action like this.

---

An informational verify `verify / show-prow-config-changes` workflow is added which will show the diff to the `jetstack/testing` repo.