### PR TITLE
update bazelbuild image for cert-manager-master

### DIFF
--- a/pkg/prowgen/globals.go
+++ b/pkg/prowgen/globals.go
@@ -18,7 +18,7 @@ package prowgen
 
 const (
 	// CommonTestImage defines the common base image used across many prow jobs
-	CommonTestImage = "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1"
+	CommonTestImage = "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1"
 
 	// AlertEmailAddress is the address to which testgrid alerts should be sent
 	AlertEmailAddress = "cert-manager-dev-alerts@googlegroups.com"


### PR DESCRIPTION
This commits the change for this PR to cmrel: https://github.com/jetstack/testing/pull/741

It's been using this image for a day and is very happy: https://testgrid.k8s.io/cert-manager-periodics-master#ci-cert-manager-master-e2e-v1-24

I realise we probably don't want to update the testing image used for 1.8 and 1.9

Signed-off-by: Joakim Ahrlin <joakim.ahrlin@gmail.com>