### PR TITLE
Run gh action on master

### DIFF
--- a/.github/workflows/generate-prow-tests-specs.yaml
+++ b/.github/workflows/generate-prow-tests-specs.yaml
@@ -1,5 +1,7 @@
 name: generate-prow-tests-specs
 on:
+  push:
+    branches: [main]
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
We want the action to run on master, so that we have an up-to-date patch for the testing repo.