### PR TITLE
Fix: move lifecycle from Test to E2ETest

### DIFF
--- a/pkg/prowgen/generators.go
+++ b/pkg/prowgen/generators.go
@@ -51,17 +51,6 @@ func MakeTest(ctx *ProwContext) *Job {
 					Memory: "4Gi",
 				},
 			},
-			Lifecycle: &Lifecycle{
-				PreStop: LifecycleHandler{
-					Exec: ExecAction{
-						Command: []string{
-							"/bin/sh",
-							"-c",
-							"make kind-logs",
-						},
-					},
-				},
-			},
 		},
 	}
 
@@ -149,6 +138,17 @@ func E2ETest(ctx *ProwContext, k8sVersion string) *Job {
 				Privileged: true,
 				Capabilities: &SecurityContextCapabilities{
 					Add: []string{"SYS_ADMIN"},
+				},
+			},
+			Lifecycle: &Lifecycle{
+				PreStop: LifecycleHandler{
+					Exec: ExecAction{
+						Command: []string{
+							"/bin/sh",
+							"-c",
+							"make kind-logs",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
@maelvls and I noticed that the tests were added to the wrong test in @jahrlin's PR (https://github.com/jetstack/testing/pull/748). I based https://github.com/cert-manager/release/pull/98 on this PR, so this is wrong.
This PR contains the fix and moves the tests to E2E.