### PR TITLE
Removes 1.25 as a Kubernetes target for cert-manager versions 1.8 and 1.9

### DIFF
--- a/prowspecs/specs.go
+++ b/prowspecs/specs.go
@@ -47,7 +47,7 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		},
 
 		primaryKubernetesVersion: "1.24",
-		otherKubernetesVersions:  []string{"1.19", "1.20", "1.21", "1.22", "1.23", "1.25"},
+		otherKubernetesVersions:  []string{"1.19", "1.20", "1.21", "1.22", "1.23"},
 
 		// see comment for BranchSpec.skipUpgradeTest
 		// Once release-1.8 is deprecated, skipUpgradeTest can be removed entirely
@@ -71,7 +71,7 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		},
 
 		primaryKubernetesVersion: "1.24",
-		otherKubernetesVersions:  []string{"1.20", "1.21", "1.22", "1.23", "1.25"},
+		otherKubernetesVersions:  []string{"1.20", "1.21", "1.22", "1.23"},
 
 		skipTrivy: true,
 	},


### PR DESCRIPTION
cert-manager versions 1.8 and 1.9 are not targeted for support for Kubernetes `v1.25`. Given that we are going to release a new cert-manager version soon with support for `v1.25`, I don't think it makes sense to be running periodic tests for it- especially when we will need to at least backport a kind version bump PR.