### PR TITLE
make k8s 1.25 default

### DIFF
--- a/prowspecs/specs.go
+++ b/prowspecs/specs.go
@@ -89,8 +89,8 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 			Repo: "cert-manager",
 		},
 
-		primaryKubernetesVersion: "1.24",
-		otherKubernetesVersions:  []string{"1.20", "1.21", "1.22", "1.23", "1.25"},
+		primaryKubernetesVersion: "1.25",
+		otherKubernetesVersions:  []string{"1.20", "1.21", "1.22", "1.23", "1.24"},
 	},
 }
 


### PR DESCRIPTION
This PR makes K8s v1.25 the default version for presubmits on master

Signed-off-by: Joakim Ahrlin <joakim.ahrlin@gmail.com>