### PR TITLE
Add ability to trigger presubmits when named files change

### DIFF
--- a/pkg/prowgen/types.go
+++ b/pkg/prowgen/types.go
@@ -118,6 +118,8 @@ type PresubmitJob struct {
 
 	AlwaysRun bool `yaml:"always_run"`
 	Optional  bool `yaml:"optional"`
+
+	RunIfChanged string `yaml:"run_if_changed,omitempty"`
 }
 
 type PeriodicJob struct {

--- a/prowspecs/specs.go
+++ b/prowspecs/specs.go
@@ -131,6 +131,8 @@ func (m *BranchSpec) GenerateJobFile() *prowgen.JobFile {
 		m.prowContext.RequiredPresubmit(prowgen.UpgradeTest(m.prowContext, m.primaryKubernetesVersion))
 	}
 
+	m.prowContext.OptionalPresubmitIfChanged(prowgen.LicenseTest(m.prowContext), `go.mod`)
+
 	m.prowContext.OptionalPresubmit(prowgen.E2ETestVenafiTPP(m.prowContext, m.primaryKubernetesVersion))
 	m.prowContext.OptionalPresubmit(prowgen.E2ETestVenafiCloud(m.prowContext, m.primaryKubernetesVersion))
 	m.prowContext.OptionalPresubmit(prowgen.E2ETestFeatureGatesDisabled(m.prowContext, m.primaryKubernetesVersion))


### PR DESCRIPTION
Also adds standalone licenses test; after this merges we can remove the licenses test from [`ci-presubmit`](https://github.com/cert-manager/cert-manager/blob/37ae8b2773c44e48df85d974ea9ea79dbacadea2/make/ci.mk#L6). 