### PR TITLE
Change alerting for trivy tests

### DIFF
--- a/pkg/prowgen/configurers.go
+++ b/pkg/prowgen/configurers.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package prowgen
 
+import "fmt"
+
 type JobConfigurer func(*Job)
 
 // jobTemplate defines a 'default' job, where standard parameters can be set. All jobs
@@ -116,11 +118,30 @@ func addStandardE2ELabels(kubernetesVersion string) JobConfigurer {
 	}
 }
 
+// addTestGridAnnotations inserts standard testgrid annotations for the job.
+// For a list of testgrid annotations, see:
+// https://github.com/GoogleCloudPlatform/testgrid/blob/444774c4b660dad5ab3c1f47e0579d37deb6b5b0/config.md#prow-job-configuration
 func addTestGridAnnotations(dashboardName string) JobConfigurer {
 	return func(job *Job) {
 		job.Annotations["testgrid-create-job-group"] = "true"
 		job.Annotations["testgrid-dashboards"] = dashboardName
 		job.Annotations["testgrid-alert-email"] = AlertEmailAddress
+	}
+}
+
+// addTestGridCustomFailuresToAlert changes the number of failures required before TestGrid
+// marks a job as "failed" (rather thank "flaky")
+func addTestGridCustomFailuresToAlert(failuresToAlert int) JobConfigurer {
+	return func(job *Job) {
+		job.Annotations["testgrid-num-failures-to-alert"] = fmt.Sprintf("%d", failuresToAlert)
+	}
+}
+
+// addTestGridStaleResultsAlert sets, in hours, the length of time before a job should be
+// considered stale. This guards against a job not running for whatever reason.
+func addTestGridStaleResultsAlert(hoursUntilStale int) JobConfigurer {
+	return func(job *Job) {
+		job.Annotations["testgrid-alert-stale-results-hours"] = fmt.Sprintf("%d", hoursUntilStale)
 	}
 }
 

--- a/pkg/prowgen/context.go
+++ b/pkg/prowgen/context.go
@@ -34,12 +34,12 @@ type ProwContext struct {
 	// Image is the common test image used for running prow jobs.
 	Image string
 
-	// PresubmitDashboard, if set, will generate a presubmit dashboard name based on the branch name
-	// for each presubmit job. If false, no presubmits will be added to a dashboard.
+	// PresubmitDashboard, if set, will generate a presubmit TestGrid dashboard name based on the branch name
+	// for each presubmit job. If false, no presubmits will be added to a TestGrid dashboard.
 	PresubmitDashboard bool
 
-	// PeriodicDashboard, if set, will generate a periodic dashboard name based on the branch name
-	// for each periodic job. If false, no periodics will be added to a dashboard.
+	// PeriodicDashboard, if set, will generate a periodic TestGrid dashboard name based on the branch name
+	// for each periodic job. If false, no periodics will be added to a TestGrid dashboard.
 	PeriodicDashboard bool
 
 	// Org is the GitHub organisation of the repository under test.

--- a/pkg/prowgen/generators.go
+++ b/pkg/prowgen/generators.go
@@ -334,6 +334,12 @@ func TrivyTest(ctx *ProwContext, containerName string) *Job {
 		addMakeVolumesLabel,
 		addDindLabel,
 		addMaxConcurrency(2),
+		// Need to ensure that trivy tests send a failure email as soon as they fail since
+		// they tend to be run relatively infrequently and a failure is important to address
+		addTestGridCustomFailuresToAlert(1),
+		// Ask TestGrid to alert us if the job hasn't run in the last 36 hours. Sets
+		// an upper limit on how regularly the job can be scheduled.
+		addTestGridStaleResultsAlert(36),
 	)
 
 	makeJobs, cpuRequest := calculateMakeConcurrency("1000m")


### PR DESCRIPTION
Ensures that if trivy tests haven't run for 36 hours we'll be alerted (we currently run every 24h).

Also ensures that any failure is treated as an actual failure which stops the test getting marked as 'flaky'