### PR TITLE
Removes k8s 1.21 tests for master

### DIFF
--- a/prowspecs/specs.go
+++ b/prowspecs/specs.go
@@ -81,10 +81,8 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 			Repo: "cert-manager",
 		},
 
-		// TODO: After the release of cert-manager 1.11, remove k8s 1.21 as it won't be supported for cert-manager 1.11
-		// See: https://cert-manager.io/docs/installation/supported-releases/
 		primaryKubernetesVersion: "1.26",
-		otherKubernetesVersions:  []string{"1.21", "1.22", "1.23", "1.24", "1.25"},
+		otherKubernetesVersions:  []string{"1.22", "1.23", "1.24", "1.25"},
 	},
 }
 


### PR DESCRIPTION
As cert-manager 1.12 will not support k8s 1.21

See https://cert-manager.io/docs/installation/supported-releases/

Signed-off-by: irbekrm <irbekrm@gmail.com>