### PR TITLE
Use make-dind, update requested resources and remove default values

### DIFF
--- a/pkg/prowgen/configurers.go
+++ b/pkg/prowgen/configurers.go
@@ -44,8 +44,12 @@ func jobTemplate(name string, description string, configurers ...JobConfigurer) 
 	return job
 }
 
-func addMakeVolumesLabel(job *Job) {
-	job.Labels["preset-make-volumes"] = "true"
+func addLocalCacheLabel(job *Job) {
+	job.Labels["preset-local-cache"] = "true"
+}
+
+func addGoCacheLabel(job *Job) {
+	job.Labels["preset-go-cache"] = "true"
 }
 
 func addServiceAccountLabel(job *Job) {
@@ -62,10 +66,6 @@ func addCloudflareCredentialsLabel(job *Job) {
 
 func addRetryFlakesLabel(job *Job) {
 	job.Labels["preset-retry-flakey-jobs"] = "true"
-}
-
-func addDefaultE2EVolumeLabels(job *Job) {
-	job.Labels["preset-default-e2e-volumes"] = "true"
 }
 
 func addGinkgoSkipDefaultLabel(job *Job) {
@@ -99,7 +99,6 @@ func addBestPracticeInstallLabel(job *Job) {
 
 func addStandardE2ELabels(kubernetesVersion string) JobConfigurer {
 	return func(job *Job) {
-		addDefaultE2EVolumeLabels(job)
 		addGinkgoSkipDefaultLabel(job)
 
 		majorVersion, minorVersion, err := splitKubernetesVersion(kubernetesVersion)

--- a/pkg/prowgen/configurers.go
+++ b/pkg/prowgen/configurers.go
@@ -27,7 +27,6 @@ type JobConfigurer func(*Job)
 func jobTemplate(name string, description string, configurers ...JobConfigurer) *Job {
 	job := &Job{
 		Name:     name,
-		Agent:    "kubernetes",
 		Decorate: true,
 		Annotations: map[string]string{
 			"description": description,

--- a/pkg/prowgen/generators.go
+++ b/pkg/prowgen/generators.go
@@ -165,7 +165,7 @@ func E2ETest(ctx *ProwContext, k8sVersion string) *Job {
 			Resources: ContainerResources{
 				Requests: ContainerResourceRequest{
 					CPU:    cpuRequest,
-					Memory: "12Gi",
+					Memory: "6Gi",
 				},
 			},
 			SecurityContext: &SecurityContext{
@@ -328,7 +328,7 @@ func UpgradeTest(ctx *ProwContext, k8sVersion string) *Job {
 			Resources: ContainerResources{
 				Requests: ContainerResourceRequest{
 					CPU:    "3500m",
-					Memory: "12Gi",
+					Memory: "6Gi",
 				},
 			},
 			SecurityContext: &SecurityContext{

--- a/pkg/prowgen/generators.go
+++ b/pkg/prowgen/generators.go
@@ -151,7 +151,7 @@ func E2ETest(ctx *ProwContext, k8sVersion string) *Job {
 		addMaxConcurrency(4),
 	)
 
-	makeJobs, cpuRequest := calculateMakeConcurrency("3500m")
+	makeJobs, cpuRequest := calculateMakeConcurrency("7000m")
 
 	k8sVersionArg := fmt.Sprintf("K8S_VERSION=%s", k8sVersion)
 

--- a/pkg/prowgen/generators.go
+++ b/pkg/prowgen/generators.go
@@ -28,7 +28,8 @@ func MakeTest(ctx *ProwContext) *Job {
 		"make-test",
 		"Runs unit and integration tests and verification scripts",
 		addServiceAccountLabel,
-		addMakeVolumesLabel,
+		addLocalCacheLabel,
+		addGoCacheLabel,
 		addMaxConcurrency(8),
 	)
 
@@ -65,7 +66,8 @@ func ChartTest(ctx *ProwContext) *Job {
 		"Verifies the Helm chart passes linting checks",
 		addServiceAccountLabel,
 		addDindLabel,
-		addMakeVolumesLabel,
+		addLocalCacheLabel,
+		addGoCacheLabel,
 		addMaxConcurrency(8),
 	)
 
@@ -102,7 +104,8 @@ func LicenseTest(ctx *ProwContext) *Job {
 		"license",
 		"Verifies LICENSES are up to date; only needs to be run if go.mod has changed",
 		addServiceAccountLabel,
-		addMakeVolumesLabel,
+		addLocalCacheLabel,
+		addGoCacheLabel,
 		addMaxConcurrency(8),
 	)
 
@@ -141,7 +144,8 @@ func E2ETest(ctx *ProwContext, k8sVersion string) *Job {
 		addServiceAccountLabel,
 		addDindLabel,
 		addCloudflareCredentialsLabel,
-		addMakeVolumesLabel,
+		addLocalCacheLabel,
+		addGoCacheLabel,
 		addStandardE2ELabels(k8sVersion),
 		addRetryFlakesLabel,
 		addMaxConcurrency(4),
@@ -201,9 +205,9 @@ func E2ETestVenafiTPP(ctx *ProwContext, k8sVersion string) *Job {
 
 	job.Labels = make(map[string]string)
 
-	addDefaultE2EVolumeLabels(job)
 	addDindLabel(job)
-	addMakeVolumesLabel(job)
+	addLocalCacheLabel(job)
+	addGoCacheLabel(job)
 	addRetryFlakesLabel(job)
 	addServiceAccountLabel(job)
 	addVenafiTPPLabels(job)
@@ -221,9 +225,9 @@ func E2ETestVenafiCloud(ctx *ProwContext, k8sVersion string) *Job {
 
 	job.Labels = make(map[string]string)
 
-	addDefaultE2EVolumeLabels(job)
 	addDindLabel(job)
-	addMakeVolumesLabel(job)
+	addLocalCacheLabel(job)
+	addGoCacheLabel(job)
 	addRetryFlakesLabel(job)
 	addServiceAccountLabel(job)
 	addVenafiCloudLabels(job)
@@ -242,9 +246,9 @@ func E2ETestVenafiBoth(ctx *ProwContext, k8sVersion string) *Job {
 
 	job.Labels = make(map[string]string)
 
-	addDefaultE2EVolumeLabels(job)
 	addDindLabel(job)
-	addMakeVolumesLabel(job)
+	addLocalCacheLabel(job)
+	addGoCacheLabel(job)
 	addRetryFlakesLabel(job)
 	addServiceAccountLabel(job)
 	addVenafiBothLabels(job)
@@ -262,11 +266,11 @@ func E2ETestFeatureGatesDisabled(ctx *ProwContext, k8sVersion string) *Job {
 	job.Labels = make(map[string]string)
 
 	addCloudflareCredentialsLabel(job)
-	addDefaultE2EVolumeLabels(job)
 	addDindLabel(job)
 	addDisableFeatureGatesLabel(job)
 	addGinkgoSkipDefaultLabel(job)
-	addMakeVolumesLabel(job)
+	addLocalCacheLabel(job)
+	addGoCacheLabel(job)
 	addRetryFlakesLabel(job)
 	addServiceAccountLabel(job)
 
@@ -285,11 +289,11 @@ func E2ETestWithBestPracticeInstall(ctx *ProwContext, k8sVersion string) *Job {
 	job.Labels = make(map[string]string)
 
 	addCloudflareCredentialsLabel(job)
-	addDefaultE2EVolumeLabels(job)
 	addDindLabel(job)
 	addDisableFeatureGatesLabel(job)
 	addGinkgoSkipDefaultLabel(job)
-	addMakeVolumesLabel(job)
+	addLocalCacheLabel(job)
+	addGoCacheLabel(job)
 	addRetryFlakesLabel(job)
 	addServiceAccountLabel(job)
 	addBestPracticeInstallLabel(job)
@@ -307,9 +311,9 @@ func UpgradeTest(ctx *ProwContext, k8sVersion string) *Job {
 		"e2e-v"+nameVersion+"-upgrade",
 		"Runs cert-manager upgrade from latest published release",
 		addServiceAccountLabel,
-		addDefaultE2EVolumeLabels,
 		addDindLabel,
-		addMakeVolumesLabel,
+		addLocalCacheLabel,
+		addGoCacheLabel,
 		addMaxConcurrency(4),
 	)
 
@@ -355,7 +359,8 @@ func TrivyTest(ctx *ProwContext, containerName string) *Job {
 		fmt.Sprintf("trivy-test-%s", containerName),
 		fmt.Sprintf("Runs a Trivy scan against the %s container", containerName),
 		addServiceAccountLabel,
-		addMakeVolumesLabel,
+		addLocalCacheLabel,
+		addGoCacheLabel,
 		addDindLabel,
 		addMaxConcurrency(2),
 		// Need to ensure that trivy tests send a failure email as soon as they fail since

--- a/pkg/prowgen/globals.go
+++ b/pkg/prowgen/globals.go
@@ -18,7 +18,7 @@ package prowgen
 
 const (
 	// CommonTestImage defines the common base image used across many prow jobs
-	CommonTestImage = "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3"
+	CommonTestImage = "eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye"
 
 	// AlertEmailAddress is the address to which testgrid alerts should be sent
 	AlertEmailAddress = "cert-manager-dev-alerts@googlegroups.com"

--- a/pkg/prowgen/types.go
+++ b/pkg/prowgen/types.go
@@ -32,8 +32,6 @@ type Job struct {
 
 	MaxConcurrency int `yaml:"max_concurrency"`
 
-	Agent string `yaml:"agent"`
-
 	Decorate bool `yaml:"decorate"`
 
 	Annotations map[string]string `yaml:"annotations"`

--- a/prowspecs/specs.go
+++ b/prowspecs/specs.go
@@ -35,8 +35,8 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		prowContext: &prowgen.ProwContext{
 			Branch: "release-1.10",
 
-			// Freeze test images used.
-			Image: "eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye",
+			// Use latest image.
+			Image: prowgen.CommonTestImage,
 
 			// NB: we don't use a presubmit dashboard outside of "master", currently
 			PresubmitDashboard: false,
@@ -53,8 +53,8 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		prowContext: &prowgen.ProwContext{
 			Branch: "release-1.11",
 
-			// Freeze test images used.
-			Image: "eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye",
+			// Use latest image.
+			Image: prowgen.CommonTestImage,
 
 			// NB: we don't use a presubmit dashboard outside of "master", currently
 			PresubmitDashboard: false,

--- a/prowspecs/specs.go
+++ b/prowspecs/specs.go
@@ -36,7 +36,7 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 			Branch: "release-1.10",
 
 			// Freeze test images used.
-			Image: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1",
+			Image: "eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye",
 
 			// NB: we don't use a presubmit dashboard outside of "master", currently
 			PresubmitDashboard: false,
@@ -54,7 +54,7 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 			Branch: "release-1.11",
 
 			// Freeze test images used.
-			Image: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1",
+			Image: "eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye",
 
 			// NB: we don't use a presubmit dashboard outside of "master", currently
 			PresubmitDashboard: false,


### PR DESCRIPTION
Based on changes we made in https://github.com/jetstack/testing

In https://github.com/jetstack/testing, we removed the -j limitations. This however has not yet proven to be a great improvement, so we shouldn't upstream that change here yet.

The value `Agent: "kubernetes",` was removed because this is the default prowjob value. An empty value is thus identical to not specifying this value.