### PR TITLE
Bump gcb images from 1.18 to 1.21

### DIFF
--- a/gcb/bootstrap-pgp/cloudbuild.yaml
+++ b/gcb/bootstrap-pgp/cloudbuild.yaml
@@ -4,7 +4,7 @@ steps:
 
 ## Clone & checkout the cert-manager release repository, build cmrel and then
 ## run the bootstrap-pgp command, which will print keys to stdout
-- name: gcr.io/cloud-builders/go:alpine-1.18
+- name: gcr.io/cloud-builders/go:alpine-1.21
   dir: "go/src/github.com/cert-manager/release"
   entrypoint: sh
   args:

--- a/gcb/publish/cloudbuild.yaml
+++ b/gcb/publish/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
 # is roughly equivalent to a labyrinth. Nothing works as expected in this image; running it
 # locally won't help. The original cmrel build below works, so I'm just copying that to end
 # the nightmares and the pain.
-- name: gcr.io/cloud-builders/go:alpine-1.18
+- name: gcr.io/cloud-builders/go:alpine-1.21
   dir: "go/src/github.com/sigstore/cosign"
   entrypoint: sh
   args:
@@ -35,7 +35,7 @@ steps:
     CGO_ENABLED=0 go build -o /workspace/go/bin/cosign ./cmd/cosign
 
 ## Clone & checkout the cert-manager release repository, then build and install
-- name: gcr.io/cloud-builders/go:alpine-1.18
+- name: gcr.io/cloud-builders/go:alpine-1.21
   dir: "go/src/github.com/cert-manager/release"
   entrypoint: sh
   args:

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
     git clone "${_CM_REPO}" . && git checkout "${_CM_REF}"
 
 ## Clone & checkout the cert-manager release repository
-- name: gcr.io/cloud-builders/go:alpine-1.18
+- name: gcr.io/cloud-builders/go:alpine-1.21
   dir: "go/src/github.com/cert-manager/release"
   entrypoint: sh
   args:

--- a/gcb/test/helm/cloudbuild.yaml
+++ b/gcb/test/helm/cloudbuild.yaml
@@ -11,7 +11,7 @@
 # (Please do not remove this security notice.)
 steps:
 
-  - name: gcr.io/cloud-builders/go:alpine-1.18
+  - name: gcr.io/cloud-builders/go:alpine-1.21
   dir: "go/src/github.com/cert-manager/release"
   entrypoint: sh
   secretEnv:


### PR DESCRIPTION
I'm trying to fix this issue: https://console.cloud.google.com/cloud-build/builds/2951bbf6-86cd-4c36-8d5c-f7a111c31c07?project=cert-manager-release