### PR TITLE
Skip shipping cmctl for v1.15.0-alpha.0 and above

### DIFF
--- a/cmd/cmrel/cmd/gcb_stage.go
+++ b/cmd/cmrel/cmd/gcb_stage.go
@@ -216,7 +216,7 @@ func runGCBStage(rootOpts *rootOptions, o *gcbStageOptions) error {
 				}
 			}
 
-			if release.IsClientOS(osVariant) {
+			if release.IsClientOS(osVariant) && release.CmctlIsShipped(releaseVersion) {
 				// add an artifact for the os and arch specific 'cmctl' and 'kubectl-cert_manager' release tarball
 				for _, kind := range []string{"kubectl-cert_manager", "cmctl"} {
 					clientArtifactName := fmt.Sprintf("cert-manager-%s-%s-%s.tar.gz", kind, osVariant, arch)

--- a/pkg/release/platforms.go
+++ b/pkg/release/platforms.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/blang/semver"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -171,4 +172,10 @@ func IsServerOS(os string) bool {
 func IsClientOS(os string) bool {
 	_, isClient := ClientPlatforms[os]
 	return isClient
+}
+
+// Cmctl is only shipped with v1.14.X and below.
+func CmctlIsShipped(releaseVersion string) bool {
+	releaseVersion, _ = strings.CutPrefix(releaseVersion, "v")
+	return semver.MustParse(releaseVersion).LT(semver.MustParse("1.15.0-alpha.0"))
 }

--- a/pkg/release/platforms_test.go
+++ b/pkg/release/platforms_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package release
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -161,6 +162,31 @@ func TestArchListFromString(t *testing.T) {
 			if !reflect.DeepEqual(test.expectedArches, output) {
 				t.Errorf("expected %#v but got %#v", test.expectedArches, output)
 				return
+			}
+		})
+	}
+}
+
+func TestCmctlIsShipped(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"1.13.0", true},
+		{"1.14.0", true},
+		{"1.14.0", true},
+		{"1.14.1", true},
+		{"1.14.2-beta.0", true},
+
+		{"1.15.0-alpha.0", false},
+		{"1.15.0-beta.0", false},
+		{"1.15.0", false},
+		{"1.15.1", false},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s", tt.version), func(t *testing.T) {
+			if got := CmctlIsShipped(tt.version); got != tt.want {
+				t.Errorf("isPre114() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/release/unpacker.go
+++ b/pkg/release/unpacker.go
@@ -43,7 +43,7 @@ type Unpacked struct {
 	GitCommitRef          string
 	Charts                []manifests.Chart
 	YAMLs                 []manifests.YAML
-	CtlBinaryBundles      []binaries.Archive
+	CtlBinaryBundles      []binaries.Archive // Only in v1.14.X and below.
 	ComponentImageBundles map[string][]*images.Tar
 }
 
@@ -95,11 +95,14 @@ func Unpack(ctx context.Context, s *Staged) (*Unpacked, error) {
 	}
 	log.Printf("Extracted %d component bundles from images archive", len(bundles))
 
-	ctlBinaryBundles, err := unpackCtlFromRelease(ctx, s)
-	if err != nil {
-		return nil, err
+	var ctlBinaryBundles []binaries.Archive
+	if CmctlIsShipped(s.meta.ReleaseVersion) {
+		ctlBinaryBundles, err := unpackCtlFromRelease(ctx, s)
+		if err != nil {
+			return nil, err
+		}
+		log.Printf("Extracted %d multi arch ctl bundles from cmctl and kubectl-cert_manager archives", len(ctlBinaryBundles))
 	}
-	log.Printf("Extracted %d multi arch ctl bundles from cmctl and kubectl-cert_manager archives", len(ctlBinaryBundles))
 
 	return &Unpacked{
 		ReleaseName:           s.Name(),

--- a/pkg/release/validation/validate.go
+++ b/pkg/release/validation/validate.go
@@ -50,7 +50,8 @@ func ValidateUnpackedRelease(opts Options, rel *release.Unpacked) ([]string, err
 			violations = append(violations, fmt.Sprintf("Helm chart sets 'appVersion' to %q, expected %q", ch.AppVersion(), opts.ReleaseVersion))
 		}
 	}
-	if len(rel.CtlBinaryBundles) == 0 {
+
+	if release.CmctlIsShipped(opts.ReleaseVersion) && len(rel.CtlBinaryBundles) == 0 {
 		violations = append(violations, fmt.Sprintf("No ctl binaries found in release - this is probably an error!"))
 	}
 	return violations, nil


### PR DESCRIPTION
We removed cmctl from the `./cmd/ctl` in the main repository and moved it in the repository https://github.com/cert-manager/cmctl.

I propose to add some logic that will skip the binaries and containers for `./cmd/ctl`.

~I'm not sure how this will play out for the `startupapicheck` container used in the Helm chart since the Helm chart currently uses a single version for all containers. We need to figure this out before this PR is merged!~ All is well since the startupapicheck binary still belongs to the cert-manager project and will still be pushed.

**Manual testing while releasing 1.15.0-alpha.0**

First, I had to point to my branch (rg = ripgrep):

```bash
rg _RELEASE_REPO_REF --files-with-matches \
  | xargs perl -pi -e 's/_RELEASE_REPO_REF:.*/_RELEASE_REPO_REF: "skip-cmctl-older-versions"/g'
```

Then:

```bash
go run ./cmd/cmrel publish --release-name v1.15.0-alpha.0
```

It passed: https://console.cloud.google.com/cloud-build/builds;region=global/a34b853b-bfe7-4af6-b649-d9a14af851da;tab=detail?project=cert-manager-release

Then, I tested `--nomock`:

```bash
go run ./cmd/cmrel publish --release-name v1.15.0-alpha.0 --nomock
```

It also passed: https://console.cloud.google.com/cloud-build/builds/afd44d68-cc93-470c-ac2b-e862b6071017?project=1021342095237