### PR TITLE
Various fixes for cmrel

### DIFF
--- a/gcb/bootstrap-pgp/cloudbuild.yaml
+++ b/gcb/bootstrap-pgp/cloudbuild.yaml
@@ -4,19 +4,22 @@ steps:
 
 ## Clone & checkout the cert-manager release repository, build cmrel and then
 ## run the bootstrap-pgp command, which will print keys to stdout
-- name: gcr.io/cloud-builders/go:alpine-1.21
-  dir: "go/src/github.com/cert-manager/release"
+- name: docker.io/library/golang:1.22-alpine
   entrypoint: sh
   args:
   - -c
   - |
     set -e
-    git clone "${_RELEASE_REPO_URL}" . && git checkout "${_RELEASE_REPO_REF}"
-    CGO_ENABLED=0 go build -o /workspace/go/bin/cmrel ./cmd/cmrel
-    /workspace/go/bin/cmrel gcb bootstrap-pgp --key=${_KMS_KEY}
+    go install github.com/cert-manager/release/cmd/cmrel@${_RELEASE_REPO_REF}
+    /go/bin/cmrel gcb bootstrap-pgp --key=${_KMS_KEY}
 
 tags:
 - "cert-manager-release-bootstrap-pgp"
+
+options:
+  volumes:
+  - name: go-modules
+    path: /go
 
 # Use the --substitutions=_OS=linux,_ARCH=arm64 flag to gcloud build submit to
 # override these values
@@ -24,7 +27,6 @@ substitutions:
   ## Required parameters
   _KMS_KEY: ""
   ## Options controlling the version of the release tooling used in the build.
-  _RELEASE_REPO_URL: https://github.com/cert-manager/release.git
   _RELEASE_REPO_REF: "master"
 
 # we don't specify a machineType manually because we don't need high CPU at all for this

--- a/gcb/publish/cloudbuild.yaml
+++ b/gcb/publish/cloudbuild.yaml
@@ -18,32 +18,17 @@ secrets:
     DOCKER_CONFIG: CiQAPjqeEyZx+aSgFNoW7KQ4wE4hp/9vbWElifjHJNTI0/71ywMSkwIAUOH2xwTfrn72i6p+Op2PYnjDfwMBcInMEtgKAqiTsaup3R5HeL8BsZGuWxVhCEm5CJJ0Rg3CPdFUx2IVmCfC3j32LkAiMxMpszdHTjWHEyWmxwtBlTJW8NFmoYzxfN4Ox9rYFF66eZ0XVdLz1UejXpqAkGFVzTzQSu4rvNFnAsP5Sj7ZKJpXn+p0ZZW1IdMTD0xzCwZjW9hhcTjyNaCKDJYwl8j6Y/bYeoUMrzDQNk48fzKIBgxEdUTR2OOAI785GWSrkB4Y03oEyrfw8jTd1yAoil2S6p3AGV1FbvFleajSCy3Ov+5gjomjtqCbTx06hVsTcqLHC45WzAWPa/8TsiXh5PPgBbkg+pfBQUTj6i9+WA==
 
 steps:
-
-## Clone & checkout the cosign repository, then build and install
-# You'd think we could just use "go install" but the gopath setup in this builder container
-# is roughly equivalent to a labyrinth. Nothing works as expected in this image; running it
-# locally won't help. The original cmrel build below works, so I'm just copying that to end
-# the nightmares and the pain.
-- name: gcr.io/cloud-builders/go:alpine-1.21
-  dir: "go/src/github.com/sigstore/cosign"
-  entrypoint: sh
+- name: docker.io/library/golang:1.22-alpine
+  entrypoint: go
   args:
-  - -c
-  - |
-    set -e
-    git clone "${_COSIGN_REPO_URL}" . && git checkout "${_COSIGN_REPO_REF}"
-    CGO_ENABLED=0 go build -o /workspace/go/bin/cosign ./cmd/cosign
+  - install
+  - github.com/cert-manager/release/cmd/cmrel@${_RELEASE_REPO_REF}
 
-## Clone & checkout the cert-manager release repository, then build and install
-- name: gcr.io/cloud-builders/go:alpine-1.21
-  dir: "go/src/github.com/cert-manager/release"
-  entrypoint: sh
+- name: docker.io/library/golang:1.22-alpine
+  entrypoint: go
   args:
-  - -c
-  - |
-    set -e
-    git clone "${_RELEASE_REPO_URL}" . && git checkout "${_RELEASE_REPO_REF}"
-    CGO_ENABLED=0 go build -o /workspace/go/bin/cmrel ./cmd/cmrel
+  - install
+  - github.com/sigstore/cosign/cmd/cosign@${_COSIGN_REPO_REF}
 
 ## Write DOCKER_CONFIG file to $HOME/.docker/config.json
 - name: gcr.io/cloud-builders/docker:19.03.8
@@ -59,7 +44,7 @@ steps:
 ## Build and push the release artifacts
 - name: gcr.io/cloud-builders/docker:19.03.8
   dir: "go/src/github.com/cert-manager/cert-manager"
-  entrypoint: /workspace/go/bin/cmrel
+  entrypoint: /go/bin/cmrel
   secretEnv:
   - GITHUB_TOKEN
   args:
@@ -77,11 +62,16 @@ steps:
   - --publish-actions=${_PUBLISH_ACTIONS}
   - --signing-kms-key=${_KMS_KEY}
   - --skip-signing=${_SKIP_SIGNING}
-  - --cosign-path=${_COSIGN_PATH}
+  - --cosign-path=/go/bin/cosign
 
 tags:
 - "cert-manager-release-publish"
 - "name-${_TAG_RELEASE_NAME}"
+
+options:
+  volumes:
+  - name: go-modules
+    path: /go
 
 # Use the --substitutions=_OS=linux,_ARCH=arm64 flag to gcloud build submit to
 # override these values
@@ -92,9 +82,6 @@ substitutions:
   _KMS_KEY: "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/cryptoKeyVersions/1"
   _SKIP_SIGNING: "false"
   _RELEASE_BUCKET: ""
-  ## Options controlling the version of the release tooling used in the build.
-  _RELEASE_REPO_URL: https://github.com/cert-manager/release.git
-  _RELEASE_REPO_REF: "master"
   _NO_MOCK: "false"
   _PUBLISHED_GITHUB_ORG: ""
   _PUBLISHED_GITHUB_REPO: ""
@@ -106,7 +93,7 @@ substitutions:
   _PUBLISH_ACTIONS: "*"
   ## Used as a tag to identify the build more easily later
   _TAG_RELEASE_NAME: ""
-  ## Cosign details
-  _COSIGN_REPO_URL: https://github.com/sigstore/cosign
-  _COSIGN_REPO_REF: "v1.5.2"
-  _COSIGN_PATH: "/workspace/go/bin/cosign"
+  ## Ref for cert-manager/release repo to use when installing cmrel
+  _RELEASE_REPO_REF: "master"
+  ## Version of the cosign tool to install
+  _COSIGN_REPO_REF: "v1.13.6"

--- a/gcb/stage/cloudbuild.yaml
+++ b/gcb/stage/cloudbuild.yaml
@@ -12,21 +12,17 @@ steps:
     set -e
     git clone "${_CM_REPO}" . && git checkout "${_CM_REF}"
 
-## Clone & checkout the cert-manager release repository
-- name: gcr.io/cloud-builders/go:alpine-1.21
-  dir: "go/src/github.com/cert-manager/release"
-  entrypoint: sh
+steps:
+- name: docker.io/library/golang:1.22-alpine
+  entrypoint: go
   args:
-  - -c
-  - |
-    set -e
-    git clone "${_RELEASE_REPO_URL}" . && git checkout "${_RELEASE_REPO_REF}"
-    CGO_ENABLED=0 go build -o /workspace/go/bin/cmrel ./cmd/cmrel
+  - install
+  - github.com/cert-manager/release/cmd/cmrel@${_RELEASE_REPO_REF}
 
 ## Build and push the release artifacts
 - name: 'gcr.io/cloud-builders/bazel@${_BAZEL_IMAGE_SHA}'
   dir: "go/src/github.com/cert-manager/cert-manager"
-  entrypoint: /workspace/go/bin/cmrel
+  entrypoint: /go/bin/cmrel
   args:
   - gcb
   - stage
@@ -44,6 +40,11 @@ tags:
 - "bazel-${_BAZEL_VERSION}"
 - "ref-${_CM_REF}"
 - "branch-${_TAG_RELEASE_BRANCH}"
+
+options:
+  volumes:
+  - name: go-modules
+    path: /go
 
 # Use the --substitutions=_OS=linux,_ARCH=arm64 flag to gcloud build submit to
 # override these values
@@ -65,7 +66,6 @@ substitutions:
   _TARGET_OSES: "*"
   _TARGET_ARCHES: "*"
   ## Options controlling the version of the release tooling used in the build.
-  _RELEASE_REPO_URL: https://github.com/cert-manager/release.git
   _RELEASE_REPO_REF: "master"
   ## Used as a tag to identify the build more easily later
   _TAG_RELEASE_BRANCH: ""

--- a/gcb/test/helm/cloudbuild.yaml
+++ b/gcb/test/helm/cloudbuild.yaml
@@ -11,7 +11,7 @@
 # (Please do not remove this security notice.)
 steps:
 
-  - name: gcr.io/cloud-builders/go:alpine-1.21
+- name: docker.io/library/golang:1.22-alpine
   dir: "go/src/github.com/cert-manager/release"
   entrypoint: sh
   secretEnv:

--- a/pkg/release/unpacker.go
+++ b/pkg/release/unpacker.go
@@ -97,10 +97,12 @@ func Unpack(ctx context.Context, s *Staged) (*Unpacked, error) {
 
 	var ctlBinaryBundles []binaries.Archive
 	if CmctlIsShipped(s.meta.ReleaseVersion) {
-		ctlBinaryBundles, err := unpackCtlFromRelease(ctx, s)
+		var err error
+		ctlBinaryBundles, err = unpackCtlFromRelease(ctx, s)
 		if err != nil {
 			return nil, err
 		}
+
 		log.Printf("Extracted %d multi arch ctl bundles from cmctl and kubectl-cert_manager archives", len(ctlBinaryBundles))
 	}
 


### PR DESCRIPTION
1. We need to use golang 1.22 images now that cmrel requires go1.22
2. There are no "cloud-builders" go 1.22 images so we need to switch to the docker `golang` images
3. That requires a few changes to the build steps to make it work
4. There's also a bug introduced in #168 which means that cmctl binaries aren't actually unpacked correctly
5. Also bumps the cosign version to the latest v1 (there's v2 available but I'm not fighting that battle yet)

[This cmrel publish dry-run](https://console.cloud.google.com/cloud-build/builds/3f4e48ef-b690-45a6-a682-9a5365b5eb0a?project=cert-manager-release) was run using this branch for this repo, which shows that the code fix works.