### PR TITLE
Reduce parallelism and use supported machine type for makestage

### DIFF
--- a/gcb/makestage/cloudbuild.yaml
+++ b/gcb/makestage/cloudbuild.yaml
@@ -1,8 +1,16 @@
-timeout: 14400s
+# This cloudbuild config file is intended to be triggered when a tag is pushed to the cert-manager repo
+# and will build a cert-manager release and push to Google Cloud Storage (GCS).
+
+# The release won't be published automatically; this file just defines the build steps.
+
+# The full release and publish process is documented here:
+# https://cert-manager.io/docs/contributing/release-process/
+
+timeout: 2700s # 45m
 
 steps:
-
-## Clone & checkout the cert-manager repository
+# cert-manager relies on the git checkout to determine release version, among other things
+# By default, gcb only does a shallow clone, so we need to "unshallow" to get more details
 - name: gcr.io/cloud-builders/git
   dir: "go/src/github.com/cert-manager/cert-manager"
   entrypoint: bash
@@ -13,7 +21,7 @@ steps:
     git clone "${_CM_REPO}" . && git checkout "${_CM_REF}"
 
 ## Build release artifacts and push to a bucket
-- name: 'eu.gcr.io/jetstack-build-infra-images/bazelbuild:${_BUILDER_IMAGE_TAG}'
+- name: 'europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:${_BUILDER_IMAGE_TAG}'
   dir: "go/src/github.com/cert-manager/cert-manager"
   entrypoint: bash
   args:
@@ -21,7 +29,7 @@ steps:
   - |
     set -eu -o pipefail
     make vendor-go
-    make CMREL_KEY="${_KMS_KEY}" RELEASE_TARGET_BUCKET="${_RELEASE_TARGET_BUCKET}" -j16 upload-release
+    make CMREL_KEY="${_KMS_KEY}" RELEASE_TARGET_BUCKET="${_RELEASE_TARGET_BUCKET}" -j8 upload-release
     echo "Wrote to ${_RELEASE_TARGET_BUCKET}"
 
 tags:
@@ -33,7 +41,9 @@ substitutions:
   _CM_REPO: "https://github.com/cert-manager/cert-manager.git"
   _KMS_KEY: "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/cryptoKeyVersions/1"
   _RELEASE_TARGET_BUCKET: "cert-manager-release"
-  _BUILDER_IMAGE_TAG: "20220629-ee75d11-4.2.1"
+  _BUILDER_IMAGE_TAG: "20240422-6b43e85-bookworm"
 
 options:
-  machineType: n1-highcpu-32
+  # https://cloud.google.com/build/docs/optimize-builds/increase-vcpu-for-builds
+  # https://cloud.google.com/build/pricing
+  machineType: E2_HIGHCPU_32

--- a/gcb/makestage/cloudbuild.yaml
+++ b/gcb/makestage/cloudbuild.yaml
@@ -1,3 +1,17 @@
+# This is a copy of https://github.com/cert-manager/cert-manager/blob/master/gcb/build_cert_manager.yaml
+# with the following modifications in this version:
+# - The git clone and checkout allows the user to override the repo and ref, to allow testing with forks and branches)
+# - The builder image tag can be overridden, to allow testing new builder images.
+#
+# This version is intended for use with `cmrel makestage`,
+# the version in `cert-manager/cert-manager` run directly by GCB, triggered by
+# the creation of a Git tag.
+#
+# ---
+#
+# If the triggered build fails, while you are releasing cert-manager, you can
+# use `cmrel makestage` to retry the failed build.
+
 # This cloudbuild config file is intended to be triggered when a tag is pushed to the cert-manager repo
 # and will build a cert-manager release and push to Google Cloud Storage (GCS).
 


### PR DESCRIPTION
Fixes: https://github.com/cert-manager/cert-manager/issues/7307
 * https://github.com/cert-manager/cert-manager/issues/7307

Assuming that the build failures are caused by OOM so testing whether reducing the parallelism might reduce the peak memory.


## Testing
I ran `cmrel makestage` with this version of the cloudbuild.yaml file, and it succeeded.

> Total build time: 2 min 52 sec

- https://console.cloud.google.com/cloud-build/builds;region=global/8811ffbb-3ed0-46d1-8ffa-8c32fe5ab0a5;tab=detail?project=cert-manager-release

```console
$ cmrel makestage --ref=v1.16.0-beta.0
2024/09/26 10:52:01 Root options:
2024/09/26 10:52:01   Debug: false
2024/09/26 10:52:01 Stage options:
2024/09/26 10:52:01   Bucket: "cert-manager-release"
2024/09/26 10:52:01   Org: "cert-manager"
2024/09/26 10:52:01   Repo: "cert-manager"
2024/09/26 10:52:01   Ref: "v1.16.0-beta.0"
2024/09/26 10:52:01   CloudBuildFile: "./gcb/makestage/cloudbuild.yaml"
2024/09/26 10:52:01   Project: "cert-manager-release"
2024/09/26 10:52:01   PublishedImageRepo: "quay.io/jetstack"
2024/09/26 10:52:01   SigningKMSKey: "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/cryptoKeyVersions/1"
2024/09/26 10:52:01 ---
2024/09/26 10:52:01 Staging build for cert-manager/cert-manager@v1.16.0-beta.0
2024/09/26 10:52:01 DEBUG: Loading cloudbuild.yaml file from "./gcb/makestage/cloudbuild.yaml"
2024/09/26 10:52:01 DEBUG: building google cloud build API client
2024/09/26 10:52:01 Submitting GCB build job...
2024/09/26 10:52:02 DEBUG: decoding build operation metadata
2024/09/26 10:52:02 ---
2024/09/26 10:52:02 Submitted build with name: "8811ffbb-3ed0-46d1-8ffa-8c32fe5ab0a5"
2024/09/26 10:52:02   View logs at: https://console.cloud.google.com/cloud-build/builds/8811ffbb-3ed0-46d1-8ffa-8c32fe5ab0a5?project=1021342095237
2024/09/26 10:52:02   Log bucket: gs://1021342095237.cloudbuild-logs.googleusercontent.com
2024/09/26 10:52:02 ---
2024/09/26 10:52:02 Waiting for build to complete, this may take a while...
...
2024/09/26 10:55:43 Release build complete for cert-manager/cert-manager@v1.16.0-beta.0
```