### PR TITLE
Let's set the 'logsBucket' field now that we are using a user-specified service account

### DIFF
--- a/gcb/publish/cloudbuild.yaml
+++ b/gcb/publish/cloudbuild.yaml
@@ -73,6 +73,7 @@ options:
   volumes:
   - name: go-modules
     path: /go
+  logging: GCS_ONLY
 
 # Use the --substitutions=_OS=linux,_ARCH=arm64 flag to gcloud build submit to
 # override these values
@@ -98,3 +99,6 @@ substitutions:
   _RELEASE_REPO_REF: "master"
   ## Version of the cosign tool to install
   _COSIGN_REPO_REF: "v1.13.6"
+
+serviceAccount: projects/cert-manager-release/serviceAccounts/cert-manager-release-gcb@cert-manager-release.iam.gserviceaccount.com
+logsBucket: gs://cert-manager-release-logs


### PR DESCRIPTION
**Companion PRs:**
- https://github.com/cert-manager/cert-manager/pull/8857
- https://github.com/cert-manager/infrastructure/pull/83

We used to use the 'legacy' Cloud Build service account that already had access to the default logging bucket, so it didn't need extra privileges.

When we moved to using a user-specified service account (cert-manager-release-gcb), the cloud build executor could no longer access the default logging bucket. So I've created a dedicated bucket for it.

For context, here is the error in question:

    Failed to trigger build: if 'build.service_account' is specified, the build
    must either (a) specify 'build.logs_bucket', (b) use the
    REGIONAL_USER_OWNED_BUCKET build.options.default_logs_bucket_behavior option,
    or (c) use either CLOUD_LOGGING_ONLY / NONE logging options: invalid argument

