### PR TITLE
Make Renovate ignore more testdata updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
   "packageRules": [
     {
       "matchFileNames": [
-        "testdata/**"
+        "**/testdata/**"
       ],
       "enabled": false
     }


### PR DESCRIPTION
I would love to avoid PRs like this one: https://github.com/cert-manager/release/pull/321