### PR TITLE
fix: verify staged metadata.json authenticity before signing and publishing

### DIFF
--- a/cmd/cmrel/cmd/gcb_publish.go
+++ b/cmd/cmrel/cmd/gcb_publish.go
@@ -98,6 +98,10 @@ type gcbPublishOptions struct {
 	// release will be published to.
 	PublishedGitHubRepo string
 
+	// ExpectedMetadataSHA256, if set, is the hex-encoded SHA-256 digest that the
+	// staged metadata.json must match before the release is unpacked and published.
+	ExpectedMetadataSHA256 string
+
 	// SkipSigning, if true, will skip trying to sign artifacts using KMS
 	SkipSigning bool
 
@@ -187,6 +191,7 @@ func (o *gcbPublishOptions) AddFlags(fs *flag.FlagSet, markRequired func(string)
 	fs.StringVar(&o.PublishedGitHubRepo, "published-github-repo", release.DefaultGitHubRepo, "The repo name in the provided org where the release will be published to.")
 	fs.StringVar(&o.CosignPath, "cosign-path", "cosign", "Full path to the cosign binary. Defaults to searching in $PATH for a binary called 'cosign'")
 	fs.StringVar(&o.SigningKMSKey, "signing-kms-key", defaultKMSKey, "Full name of the GCP KMS key to use for signing.")
+	fs.StringVar(&o.ExpectedMetadataSHA256, "expected-metadata-sha256", "", "If set, the hex-encoded SHA-256 digest of the staged metadata.json is verified against this value before the release is unpacked. Obtain this value out-of-band from the 'gcb stage' build log to ensure the staged release has not been tampered with. If empty, the check is skipped and a warning is logged.")
 	fs.BoolVar(&o.SkipSigning, "skip-signing", false, "Skip signing container images.")
 	fs.StringSliceVar(&o.PublishActions, "publish-actions", []string{"*"}, fmt.Sprintf("Comma-separated list of actions to take, or '*' to do everything. Only meaningful if nomock is set. Operations are done in alphabetical order. Actions can be removed with a prefix of '-'. Options: %s", strings.Join(allPublishActionNames(), ", ")))
 }
@@ -205,6 +210,7 @@ func (o *gcbPublishOptions) print() {
 	log.Printf("  CosignPath: %q", o.CosignPath)
 	log.Printf("  SkipSigning: %v", o.SkipSigning)
 	log.Printf("  SigningKMSKey: %q", o.SigningKMSKey)
+	log.Printf("  ExpectedMetadataSHA256: %q", o.ExpectedMetadataSHA256)
 	log.Printf("  PublishActions: %q", strings.Join(o.PublishActions, ","))
 }
 
@@ -309,6 +315,11 @@ func runGCBPublish(rootOpts *rootOptions, o *gcbPublishOptions) error {
 
 	log.Printf("Release with version %q (%s) will be published", staged.Metadata().ReleaseVersion, staged.Metadata().GitCommitRef)
 
+	// Verify the integrity of the staged metadata.json before trusting anything it describes.
+	if err := verifyStagedMetadata(o, staged); err != nil {
+		return err
+	}
+
 	rel, err := release.Unpack(ctx, staged)
 	if err != nil {
 		return fmt.Errorf("failed to unpack staged release: %w", err)
@@ -367,6 +378,25 @@ func runGCBPublish(rootOpts *rootOptions, o *gcbPublishOptions) error {
 	log.Printf("+++++++++ Publishing release completed successfully! +++++++++")
 	log.Printf("You MUST now perform the following manual tasks:\n%s", o.ManualActionText())
 
+	return nil
+}
+
+// verifyStagedMetadata compares the SHA-256 digest of the staged metadata.json
+// against the expected value supplied by the operator.
+func verifyStagedMetadata(o *gcbPublishOptions, staged *release.Staged) error {
+	actual := staged.MetadataSHA256()
+
+	if o.ExpectedMetadataSHA256 == "" {
+		log.Printf("WARNING: --expected-metadata-sha256 was not set; skipping staged metadata authenticity check. "+
+			"The staged metadata.json (sha256 %s) is being trusted without out-of-band verification.", actual)
+		return nil
+	}
+
+	if !strings.EqualFold(strings.TrimSpace(o.ExpectedMetadataSHA256), actual) {
+		return fmt.Errorf("staged metadata.json sha256 %q does not match expected value %q - refusing to publish", actual, o.ExpectedMetadataSHA256)
+	}
+
+	log.Printf("Verified staged metadata.json against expected sha256 %s", actual)
 	return nil
 }
 

--- a/cmd/cmrel/cmd/gcb_stage.go
+++ b/cmd/cmrel/cmd/gcb_stage.go
@@ -306,6 +306,11 @@ func runGCBStage(rootOpts *rootOptions, o *gcbStageOptions) error {
 		return err
 	}
 
+	// Emit the digest of the metadata.json we just uploaded.
+	metaSum := sha256.Sum256(meta)
+	log.Printf("Staged metadata.json sha256: %s", hex.EncodeToString(metaSum[:]))
+	log.Printf("Pass this digest to 'cmrel publish --expected-metadata-sha256=<digest>' to verify the staged release before publishing")
+
 	log.Printf("Successfully staged release with version %q", releaseVersion)
 
 	return nil

--- a/cmd/cmrel/cmd/publish.go
+++ b/cmd/cmrel/cmd/publish.go
@@ -97,6 +97,10 @@ type publishOptions struct {
 	// or else "*" - the default - to mean "all actions"
 	PublishActions []string
 
+	// ExpectedMetadataSHA256, if set, is the hex-encoded SHA-256 digest that the
+	// staged metadata.json must match before the publish job unpacks and publishes the release.
+	ExpectedMetadataSHA256 string
+
 	// SkipSigning, if true, will skip trying to sign artifacts using KMS
 	SkipSigning bool
 
@@ -120,6 +124,7 @@ func (o *publishOptions) AddFlags(fs *flag.FlagSet, markRequired func(string)) {
 	fs.StringVar(&o.PublishedGitHubOrg, "published-github-org", release.DefaultGitHubOrg, "The org of the repository where the release wil be published to.")
 	fs.StringVar(&o.PublishedGitHubRepo, "published-github-repo", release.DefaultGitHubRepo, "The repo name in the provided org where the release will be published to.")
 	fs.StringVar(&o.SigningKMSKey, "signing-kms-key", defaultKMSKey, "Full name of the GCP KMS key to use for signing.")
+	fs.StringVar(&o.ExpectedMetadataSHA256, "expected-metadata-sha256", "", "If set, the hex-encoded SHA-256 digest of the staged metadata.json is verified against this value by the publish job before the release is published. Obtain this value out-of-band from the 'gcb stage' build log to ensure the staged release has not been tampered with.")
 	fs.BoolVar(&o.SkipSigning, "skip-signing", false, "Skip signing container images.")
 	fs.StringSliceVar(&o.PublishActions, "publish-actions", []string{"*"}, fmt.Sprintf("Comma-separated list of actions to take, or '*' to do everything. Only meaningful if nomock is set. Order of operations is preserved if given, or is alphabetical by default. Actions can be removed with a prefix of '-'. Options: %s", strings.Join(allPublishActionNames(), ", ")))
 }
@@ -138,6 +143,7 @@ func (o *publishOptions) print() {
 	log.Printf("  PublishedGitHubOrg: %q", o.PublishedGitHubOrg)
 	log.Printf("  PublishedGitHubRepo: %q", o.PublishedGitHubRepo)
 	log.Printf("  PublishActions: %q", strings.Join(o.PublishActions, ","))
+	log.Printf("  ExpectedMetadataSHA256: %q", o.ExpectedMetadataSHA256)
 }
 
 func publishCmd(rootOpts *rootOptions) *cobra.Command {
@@ -213,6 +219,7 @@ func runPublish(rootOpts *rootOptions, o *publishOptions) error {
 	build.Substitutions["_PUBLISH_ACTIONS"] = strings.Join(o.PublishActions, ",")
 	build.Substitutions["_SKIP_SIGNING"] = fmt.Sprintf("%v", o.SkipSigning)
 	build.Substitutions["_KMS_KEY"] = o.SigningKMSKey
+	build.Substitutions["_EXPECTED_METADATA_SHA256"] = o.ExpectedMetadataSHA256
 
 	log.Printf("DEBUG: building google cloud build API client")
 	svc, err := cloudbuild.NewService(ctx)

--- a/gcb/publish/cloudbuild.yaml
+++ b/gcb/publish/cloudbuild.yaml
@@ -62,6 +62,7 @@ steps:
   - --publish-actions=${_PUBLISH_ACTIONS}
   - --signing-kms-key=${_KMS_KEY}
   - --skip-signing=${_SKIP_SIGNING}
+  - --expected-metadata-sha256=${_EXPECTED_METADATA_SHA256}
   - --cosign-path=/go/bin/cosign
 
 tags:
@@ -83,6 +84,9 @@ substitutions:
   ## Optional/defaulted parameters
   _KMS_KEY: "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/cryptoKeyVersions/1"
   _SKIP_SIGNING: "false"
+  ## Out-of-band SHA-256 digest of the staged metadata.json. When set, the
+  ## publish job refuses to publish unless the staged metadata.json matches this value.
+  _EXPECTED_METADATA_SHA256: ""
   _RELEASE_BUCKET: ""
   _NO_MOCK: "false"
   _PUBLISHED_GITHUB_ORG: ""

--- a/pkg/release/staged.go
+++ b/pkg/release/staged.go
@@ -18,8 +18,11 @@ package release
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
@@ -30,10 +33,11 @@ import (
 // It provides convenience methods to interact with release build and inspect
 // metadata.
 type Staged struct {
-	name      string
-	prefix    string
-	meta      Metadata
-	artifacts []StagedArtifact
+	name           string
+	prefix         string
+	meta           Metadata
+	metadataSHA256 string
+	artifacts      []StagedArtifact
 }
 
 // StagedArtifact represents a single artifact within a release, with some
@@ -44,7 +48,7 @@ type StagedArtifact struct {
 }
 
 func NewStagedRelease(ctx context.Context, name, prefix string, objects ...*storage.ObjectHandle) (*Staged, error) {
-	meta, err := loadReleaseMetadataFile(ctx, objects...)
+	meta, metadataSHA256, err := loadReleaseMetadataFile(ctx, objects...)
 	if err != nil {
 		return nil, err
 	}
@@ -55,10 +59,11 @@ func NewStagedRelease(ctx context.Context, name, prefix string, objects ...*stor
 	}
 
 	return &Staged{
-		name:      name,
-		prefix:    prefix,
-		meta:      *meta,
-		artifacts: artifacts,
+		name:           name,
+		prefix:         prefix,
+		meta:           *meta,
+		metadataSHA256: metadataSHA256,
+		artifacts:      artifacts,
 	}, nil
 }
 
@@ -70,6 +75,12 @@ func (s Staged) Name() string {
 // Metadata will return metadata information about the release.
 func (s Staged) Metadata() Metadata {
 	return s.meta
+}
+
+// MetadataSHA256 returns the hex-encoded SHA-256 digest of the raw metadata.json
+// object that describes this staged release.
+func (s Staged) MetadataSHA256() string {
+	return s.metadataSHA256
 }
 
 // ArtifactsOfKind returns a list of staged artifacts of the type denoted by
@@ -85,7 +96,7 @@ func (s Staged) ArtifactsOfKind(kind string) []StagedArtifact {
 	return objs
 }
 
-func loadReleaseMetadataFile(ctx context.Context, objs ...*storage.ObjectHandle) (*Metadata, error) {
+func loadReleaseMetadataFile(ctx context.Context, objs ...*storage.ObjectHandle) (*Metadata, string, error) {
 	var metadataObj *storage.ObjectHandle
 	for _, f := range objs {
 		if filepath.Base(f.ObjectName()) == MetadataFileName {
@@ -95,21 +106,28 @@ func loadReleaseMetadataFile(ctx context.Context, objs ...*storage.ObjectHandle)
 	}
 
 	if metadataObj == nil {
-		return nil, fmt.Errorf("release metadata not found")
+		return nil, "", fmt.Errorf("release metadata not found")
 	}
 
 	r, err := metadataObj.NewReader(ctx)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer r.Close()
 
-	var m Metadata
-	if err := json.NewDecoder(r).Decode(&m); err != nil {
-		return nil, err
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return nil, "", err
 	}
 
-	return &m, nil
+	var m Metadata
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, "", err
+	}
+
+	sum := sha256.Sum256(body)
+
+	return &m, hex.EncodeToString(sum[:]), nil
 }
 
 func crossReferenceArtifactMetadata(meta Metadata, name, prefix string, objs ...*storage.ObjectHandle) ([]StagedArtifact, error) {


### PR DESCRIPTION
## Description
### Problem
The gcb publish command fetches a staged release from GCS and then signs it with the project's production KMS key and pushes it to public registries. The root of trust for everything it does is metadata.json, which is read from the same GCS prefix as the artifacts it describes — and that prefix is writable by anyone holding storage.objects.create on the staging bucket, so its contents should be treated as potentially attacker-influenced. The current code trusts it with no independent anchor:

  - Self-referential integrity gate: each artifact is accepted when sha256(body) == metadata.SHA256, but both operands come from the same unsigned file, so a self-consistent {metadata.json, *.tar.gz} set passes.
  - Validation checks shape, not origin: ValidateUnpackedRelease only asserts semver formatting and tag-string equality — no provenance, commit-ref, or signature check.
  - Signing sink trusts it fully: whatever survives the gate is docker loaded, retagged as quay.io/jetstack/cert-manager-*, pushed, and cosign-signed with the production key.

### Solution

Add an out-of-band integrity anchor for metadata.json: LoadStagedRelease now exposes the SHA-256 of the exact bytes decoded, gcb publish gains --expected-metadata-sha256 and fails closed before unpacking or signing when it does not match, the value is plumbed through the _EXPECTED_METADATA_SHA256 cloudbuild substitution, and gcb stage logs the digest so operators have a trusted source. An empty flag preserves current behaviour with a warning. Legitimate releases behave unchanged.

### Test plan

  - [ ] Existing pkg/release and cmd/cmrel/cmd tests pass unchanged.
  - [ ] Manual: a matching --expected-metadata-sha256 publishes; a mismatched one is rejected before any docker
load/cosign sign; an empty value logs the warning and proceeds.
  - [ ] Pre-existing TestValidate_Semver failure confirmed unrelated (fails identically on a clean tree).
  - [ ] go build ./..., go vet ./..., and gofmt clean.