### PR TITLE
fix(release): prevent tar/zip slip path traversal in artifact extraction

### DIFF
--- a/pkg/release/tar/tarball.go
+++ b/pkg/release/tar/tarball.go
@@ -54,6 +54,12 @@ func UntarGz(dst string, r io.Reader) error {
 			continue
 		}
 
+		// reject any entry whose name would escape the destination directory
+		// (e.g. "../../go/bin/cosign" or an absolute path).
+		if !filepath.IsLocal(header.Name) {
+			return fmt.Errorf("refusing to extract %q: entry path escapes the destination directory", header.Name)
+		}
+
 		// the target location where the dir/file should be created
 		target := filepath.Join(dst, header.Name)
 
@@ -74,19 +80,25 @@ func UntarGz(dst string, r io.Reader) error {
 
 		// if it's a file create it
 		case tar.TypeReg:
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			// O_EXCL ensures we never follow into or overwrite an existing file,
+			// and we mask to permission bits so a malicious archive cannot set setuid/setgid/sticky bits.
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_EXCL, os.FileMode(header.Mode).Perm())
 			if err != nil {
 				return err
 			}
 
 			// copy over contents
 			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
 				return err
 			}
 
 			// manually close here after each file operation; defering would cause each file close
 			// to wait until all operations have completed.
 			f.Close()
+
+		case tar.TypeSymlink, tar.TypeLink:
+			return fmt.Errorf("refusing to extract %q: symlinks and hardlinks are not permitted in release archives", header.Name)
 		}
 	}
 }

--- a/pkg/release/tar/tarball_test.go
+++ b/pkg/release/tar/tarball_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tar
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// tarEntry describes a single entry to write into a test tar.gz archive.
+type tarEntry struct {
+	name     string
+	typeflag byte
+	mode     int64
+	linkname string
+	body     string
+}
+
+// buildTarGz builds an in-memory gzipped tar archive from the given entries.
+func buildTarGz(t *testing.T, entries []tarEntry) *bytes.Reader {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Name:     e.name,
+			Typeflag: e.typeflag,
+			Mode:     e.mode,
+			Linkname: e.linkname,
+			Size:     int64(len(e.body)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("failed to write tar header: %v", err)
+		}
+		if len(e.body) > 0 {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatalf("failed to write tar body: %v", err)
+			}
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("failed to close tar writer: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("failed to close gzip writer: %v", err)
+	}
+
+	return bytes.NewReader(buf.Bytes())
+}
+
+func TestUntarGz(t *testing.T) {
+	tests := map[string]struct {
+		entries   []tarEntry
+		expectErr bool
+	}{
+		"extracts a well-formed archive": {
+			entries: []tarEntry{
+				{name: "server", typeflag: tar.TypeDir, mode: 0755},
+				{name: "server/images", typeflag: tar.TypeDir, mode: 0755},
+				{name: "server/images/controller.tar", typeflag: tar.TypeReg, mode: 0644, body: "image"},
+			},
+		},
+		"rejects a parent-directory traversal entry": {
+			entries: []tarEntry{
+				{name: "../../go/bin/cosign", typeflag: tar.TypeReg, mode: 0755, body: "evil"},
+			},
+			expectErr: true,
+		},
+		"rejects an absolute-path entry": {
+			entries: []tarEntry{
+				{name: "/etc/cron.d/evil", typeflag: tar.TypeReg, mode: 0644, body: "evil"},
+			},
+			expectErr: true,
+		},
+		"rejects a symlink entry": {
+			entries: []tarEntry{
+				{name: "link", typeflag: tar.TypeSymlink, mode: 0777, linkname: "/etc/passwd"},
+			},
+			expectErr: true,
+		},
+		"rejects a hardlink entry": {
+			entries: []tarEntry{
+				{name: "link", typeflag: tar.TypeLink, mode: 0644, linkname: "../../go/bin/cosign"},
+			},
+			expectErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			dst := t.TempDir()
+			r := buildTarGz(t, test.entries)
+
+			err := UntarGz(dst, r)
+			if test.expectErr && err == nil {
+				t.Fatalf("expected an error but got none")
+			}
+			if !test.expectErr && err != nil {
+				t.Fatalf("got an unexpected error: %v", err)
+			}
+
+			if test.expectErr {
+				// Ensure nothing escaped the destination directory.
+				if _, statErr := os.Stat(filepath.Join(dst, "..", "..", "go", "bin", "cosign")); statErr == nil {
+					t.Fatalf("traversal entry escaped the destination directory")
+				}
+			}
+		})
+	}
+}

--- a/pkg/release/zip/zip.go
+++ b/pkg/release/zip/zip.go
@@ -18,6 +18,7 @@ package zip
 
 import (
 	"archive/zip"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -54,9 +55,17 @@ func writeFileFromZipArchive(dst string, f *zip.File) error {
 
 	defer rc.Close()
 
+	// reject any entry whose name would escape the destination directory
+	// (e.g. "../../go/bin/cosign" or an absolute path).
+	if !filepath.IsLocal(f.Name) {
+		return fmt.Errorf("refusing to extract %q: entry path escapes the destination directory", f.Name)
+	}
+
 	targetFilename := filepath.Join(dst, f.Name)
 
-	outFile, err := os.OpenFile(targetFilename, os.O_CREATE|os.O_RDWR, os.FileMode(f.Mode()))
+	// O_EXCL ensures we never follow into or overwrite an existing file, and we
+	// mask to permission bits so a malicious archive cannot set setuid/setgid/sticky bits.
+	outFile, err := os.OpenFile(targetFilename, os.O_CREATE|os.O_RDWR|os.O_EXCL, f.Mode().Perm())
 	if err != nil {
 		return err
 	}

--- a/pkg/release/zip/zip_test.go
+++ b/pkg/release/zip/zip_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zip
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// zipEntry describes a single entry to write into a test zip archive.
+type zipEntry struct {
+	name string
+	mode os.FileMode
+	body string
+}
+
+// buildZip writes a zip archive containing the given entries to a temp file and
+// returns the opened *os.File, seeked to the start.
+func buildZip(t *testing.T, entries []zipEntry) *os.File {
+	t.Helper()
+
+	f, err := os.CreateTemp(t.TempDir(), "archive-*.zip")
+	if err != nil {
+		t.Fatalf("failed to create temp zip: %v", err)
+	}
+
+	zw := zip.NewWriter(f)
+	for _, e := range entries {
+		hdr := &zip.FileHeader{Name: e.name}
+		hdr.SetMode(e.mode)
+		w, err := zw.CreateHeader(hdr)
+		if err != nil {
+			t.Fatalf("failed to create zip entry: %v", err)
+		}
+		if _, err := w.Write([]byte(e.body)); err != nil {
+			t.Fatalf("failed to write zip body: %v", err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		t.Fatalf("failed to seek zip: %v", err)
+	}
+
+	return f
+}
+
+func TestUnzip(t *testing.T) {
+	tests := map[string]struct {
+		entries   []zipEntry
+		expectErr bool
+	}{
+		"extracts a well-formed archive": {
+			entries: []zipEntry{
+				{name: "cmctl", mode: 0755, body: "binary"},
+				{name: "LICENSE", mode: 0644, body: "license"},
+			},
+		},
+		"rejects a parent-directory traversal entry": {
+			entries: []zipEntry{
+				{name: "../../go/bin/cosign", mode: 0755, body: "evil"},
+			},
+			expectErr: true,
+		},
+		"rejects an absolute-path entry": {
+			entries: []zipEntry{
+				{name: "/etc/cron.d/evil", mode: 0644, body: "evil"},
+			},
+			expectErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			dst := t.TempDir()
+			f := buildZip(t, test.entries)
+			defer f.Close()
+
+			err := Unzip(dst, f)
+			if test.expectErr && err == nil {
+				t.Fatalf("expected an error but got none")
+			}
+			if !test.expectErr && err != nil {
+				t.Fatalf("got an unexpected error: %v", err)
+			}
+
+			if test.expectErr {
+				if _, statErr := os.Stat(filepath.Join(dst, "..", "..", "go", "bin", "cosign")); statErr == nil {
+					t.Fatalf("traversal entry escaped the destination directory")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

## Problem
The cmrel gcb publish command downloads pre-built artifact bundles from a GCS staging area and unpacks them inside the privileged Cloud Build worker. The extractors tar.UntarGz() and zip.Unzip() write each archive entry to filepath.Join(dst, header.Name) with the entry name taken at face value — and a bundle can come from an untrusted source (anyone with write access to the staging bucket). The current code writes them with no safeguards:
  - Path traversal: entry names are joined onto the destination with no ..-stripping or absolute-path rejection, so an entry named ../../go/bin/cosign escapes the temp unpack dir and lands on the shared /go volume.
  - Arbitrary overwrite: files are opened without O_EXCL, overwriting binaries the worker is about to execute (e.g. cosign), yielding root RCE with GITHUB_TOKEN, quay creds and the KMS signing key in scope.
  - Symlink/hardlink & mode abuse: link entries are unhandled and header.Mode is used verbatim, so setuid/setgid bits and attacker-controlled link targets pass straight through.

## Solution

Guard both extractors with filepath.IsLocal() to reject absolute paths and parent-directory traversal, open regular files with O_EXCL so an entry can no longer overwrite an existing file, and mask the mode to permission bits to drop setuid/setgid/sticky. Symlink and hardlink tar entries are rejected outright. Legitimate release archives behave unchanged.

## Test plan
- [ ] TestUntarGz — traversal, absolute-path, symlink and hardlink entries are all rejected, and a well-formed archive extracts unchanged.
- [ ] TestUnzip — traversal and absolute-path entries are rejected; a well-formed archive extracts unchanged.
- [ ] Both new tests (tarball_test,zip_test) assert nothing escapes the destination directory.
- [ ] Existing pkg/release tests pass unchanged.
- [ ] go build ./..., go vet ./..., and gofmt clean.